### PR TITLE
Replace manual initialization flags with client->check_on_init()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+## Projekt
+
+abap2UI5 Samples - Sammlung von Demo-Apps für das abap2UI5 Framework.
+
+## Regeln
+
+### abaplint
+
+- **Vor jedem Commit muss `abaplint` ausgeführt werden und 0 Fehler zeigen.**
+- Konfiguration liegt in `abaplint.jsonc`.
+- Installation: `npm install -g @abaplint/cli`
+- Aufruf: `abaplint`
+
+### Code-Konventionen
+
+- Kein init-Flag als Attribut verwenden (`check_initialized`, `mv_init`, `is_initialized`, etc.). Stattdessen immer `client->check_on_init( )` nutzen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,22 @@
 # CLAUDE.md
 
-## Projekt
+## Project
 
-abap2UI5 Samples - Sammlung von Demo-Apps für das abap2UI5 Framework.
+abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 
-## Regeln
+## Language
+
+- **This entire project is in English.** All code, comments, commit messages, PR titles, PR descriptions, and any other text must be written in English.
+
+## Rules
 
 ### abaplint
 
-- **Vor jedem Commit muss `abaplint` ausgeführt werden und 0 Fehler zeigen.**
-- Konfiguration liegt in `abaplint.jsonc`.
-- Installation: `npm install -g @abaplint/cli`
-- Aufruf: `abaplint`
+- **Run `abaplint` before every commit. It must report 0 issues.**
+- Configuration: `abaplint.jsonc`
+- Install: `npm install -g @abaplint/cli`
+- Run: `abaplint`
 
-### Code-Konventionen
+### Code Conventions
 
-- Kein init-Flag als Attribut verwenden (`check_initialized`, `mv_init`, `is_initialized`, etc.). Stattdessen immer `client->check_on_init( )` nutzen.
+- Never use an init flag attribute (`check_initialized`, `mv_init`, `is_initialized`, etc.). Always use `client->check_on_init( )` instead.

--- a/src/00/z2ui5_cl_demo_app_s_01.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_01.clas.abap
@@ -7,7 +7,6 @@ CLASS z2ui5_cl_demo_app_s_01 DEFINITION
     INTERFACES z2ui5_if_app .
 
     DATA lock_counter TYPE i READ-ONLY .
-    DATA check_initialized TYPE abap_bool READ-ONLY .
     DATA session_is_stateful TYPE abap_bool READ-ONLY .
     DATA session_text TYPE string READ-ONLY .
     DATA lock_text TYPE string READ-ONLY .
@@ -138,8 +137,7 @@ CLASS z2ui5_cl_demo_app_s_01 IMPLEMENTATION.
 
         CLEAR error.
 
-        IF check_initialized = abap_false.
-          check_initialized = abap_true.
+        IF client->check_on_init( ).
           update_lock_counter( ).
           initialize_view( client ).
         ENDIF.

--- a/src/00/z2ui5_cl_demo_app_s_02.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_02.clas.abap
@@ -5,7 +5,6 @@ CLASS z2ui5_cl_demo_app_s_02 DEFINITION
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
     DATA instance_counter TYPE i READ-ONLY.
-    DATA check_initialized TYPE abap_bool READ-ONLY.
     DATA session_is_stateful TYPE abap_bool READ-ONLY.
     DATA session_text TYPE string READ-ONLY.
 
@@ -32,8 +31,7 @@ CLASS z2ui5_cl_demo_app_s_02 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     TRY.
 
-        IF check_initialized = abap_false.
-          check_initialized = abap_true.
+        IF client->check_on_init( ).
           initialize_view( client ).
         ENDIF.
 

--- a/src/z2ui5_cl_demo_app_005.clas.abap
+++ b/src/z2ui5_cl_demo_app_005.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_005 DEFINITION PUBLIC.
 
     DATA value1 TYPE int4.
     DATA value2 TYPE int4.
-    DATA initialized TYPE abap_bool.
-
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -19,8 +17,7 @@ CLASS z2ui5_cl_demo_app_005 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF initialized = abap_false.
-      initialized = abap_true.
+    IF client->check_on_init( ).
       value1 = 10.
       value2 = 90.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_056.clas.abap
+++ b/src/z2ui5_cl_demo_app_056.clas.abap
@@ -23,7 +23,6 @@ CLASS z2ui5_cl_demo_app_056 DEFINITION PUBLIC.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA mv_check_initialized TYPE abap_bool.
     METHODS on_event.
     METHODS view_display.
     METHODS set_data.
@@ -155,8 +154,7 @@ CLASS z2ui5_cl_demo_app_056 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_check_initialized = abap_false.
-      mv_check_initialized = abap_true.
+    IF client->check_on_init( ).
       view_display( ).
       RETURN.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_068.clas.abap
+++ b/src/z2ui5_cl_demo_app_068.clas.abap
@@ -27,8 +27,6 @@ CLASS z2ui5_cl_demo_app_068 DEFINITION
       ty_prodh_nodes TYPE STANDARD TABLE OF ty_prodh_node_level1 WITH DEFAULT KEY.
 
     DATA prodh_nodes    TYPE ty_prodh_nodes.
-    DATA is_initialized TYPE abap_bool.
-
     METHODS ui5_display_view
       IMPORTING
         client TYPE REF TO z2ui5_if_client.
@@ -123,8 +121,7 @@ CLASS Z2UI5_CL_DEMO_APP_068 IMPLEMENTATION.
 
     me->client = client.
 
-    IF is_initialized = abap_false.
-      is_initialized = abap_true.
+    IF client->check_on_init( ).
       ui5_initialize( ).
       ui5_display_view( client ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_072.clas.abap
+++ b/src/z2ui5_cl_demo_app_072.clas.abap
@@ -37,8 +37,6 @@ CLASS z2ui5_cl_demo_app_072 DEFINITION
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client .
-    DATA check_initialized TYPE abap_bool .
-
     METHODS z2ui5_on_init .
     METHODS z2ui5_on_event .
     METHODS z2ui5_set_data .

--- a/src/z2ui5_cl_demo_app_076.clas.abap
+++ b/src/z2ui5_cl_demo_app_076.clas.abap
@@ -43,8 +43,6 @@ CLASS z2ui5_cl_demo_app_076 DEFINITION
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client .
-    DATA check_initialized TYPE abap_bool .
-
     METHODS z2ui5_on_init .
     METHODS z2ui5_on_event .
     METHODS z2ui5_set_data .

--- a/src/z2ui5_cl_demo_app_085.clas.abap
+++ b/src/z2ui5_cl_demo_app_085.clas.abap
@@ -45,7 +45,6 @@ CLASS z2ui5_cl_demo_app_085 DEFINITION
 
     DATA mt_table TYPE ty_t_table .
     DATA mt_table_supplier TYPE ty_t_table_supplier .
-    DATA check_initialized TYPE abap_bool .
     DATA mv_search_value TYPE string.
     DATA ls_detail TYPE ty_s_tab .
   PROTECTED SECTION.

--- a/src/z2ui5_cl_demo_app_094.clas.abap
+++ b/src/z2ui5_cl_demo_app_094.clas.abap
@@ -24,8 +24,6 @@ CLASS z2ui5_cl_demo_app_094 DEFINITION PUBLIC.
     DATA mv_val    TYPE string.
 
     DATA client      TYPE REF TO z2ui5_if_client.
-    DATA mv_init     TYPE abap_bool.
-
     METHODS on_init.
     METHODS view_build.
 
@@ -128,8 +126,7 @@ CLASS Z2UI5_CL_DEMO_APP_094 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
 
     ENDIF.

--- a/src/z2ui5_cl_demo_app_095.clas.abap
+++ b/src/z2ui5_cl_demo_app_095.clas.abap
@@ -21,7 +21,6 @@ CLASS z2ui5_cl_demo_app_095 DEFINITION PUBLIC.
     DATA mo_app_sub TYPE REF TO z2ui5_cl_demo_app_096.
 
     DATA client      TYPE REF TO z2ui5_if_client.
-    DATA mv_init     TYPE abap_bool.
     DATA mo_grid_sub TYPE REF TO z2ui5_cl_xml_view.
 
     DATA mr_input  TYPE REF TO data.
@@ -131,8 +130,7 @@ CLASS Z2UI5_CL_DEMO_APP_095 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
       on_init_sub( ).
       client->view_display( page->get_root( )->xml_get( ) ).

--- a/src/z2ui5_cl_demo_app_096.clas.abap
+++ b/src/z2ui5_cl_demo_app_096.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_096 DEFINITION PUBLIC.
     DATA client TYPE REF TO z2ui5_if_client.
     DATA mo_view_parent TYPE REF TO z2ui5_cl_xml_view.
     DATA mv_descr       TYPE string.
-
-    DATA mv_init TYPE abap_bool.
     METHODS on_init.
     METHODS on_event.
 
@@ -26,8 +24,7 @@ CLASS Z2UI5_CL_DEMO_APP_096 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
       RETURN.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_097.clas.abap
+++ b/src/z2ui5_cl_demo_app_097.clas.abap
@@ -22,7 +22,6 @@ CLASS z2ui5_cl_demo_app_097 DEFINITION
     DATA t_tab TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY.
     DATA t_tab2 TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY.
     DATA mv_layout TYPE string.
-    DATA check_initialized TYPE abap_bool .
     DATA mv_check_enabled_01 TYPE abap_bool VALUE abap_true.
     DATA mv_check_enabled_02 TYPE abap_bool .
   PROTECTED SECTION.

--- a/src/z2ui5_cl_demo_app_098.clas.abap
+++ b/src/z2ui5_cl_demo_app_098.clas.abap
@@ -25,7 +25,6 @@ CLASS z2ui5_cl_demo_app_098 DEFINITION
       t_tab2 TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY .
     DATA mv_layout TYPE string .
     DATA mv_title TYPE string .
-    DATA check_initialized TYPE abap_bool .
     DATA mv_check_enabled_01 TYPE abap_bool VALUE abap_true.
     DATA mv_check_enabled_02 TYPE abap_bool .
   PROTECTED SECTION.

--- a/src/z2ui5_cl_demo_app_104.clas.abap
+++ b/src/z2ui5_cl_demo_app_104.clas.abap
@@ -28,7 +28,6 @@ CLASS z2ui5_cl_demo_app_104 DEFINITION
       t_tab2 TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY .
     DATA mv_layout TYPE string .
     DATA mv_title TYPE string .
-    DATA check_initialized TYPE abap_bool .
     DATA mv_check_enabled_01 TYPE abap_bool VALUE abap_true.
     DATA mv_check_enabled_02 TYPE abap_bool .
     DATA mo_grid_sub TYPE REF TO z2ui5_cl_xml_view .

--- a/src/z2ui5_cl_demo_app_105.clas.abap
+++ b/src/z2ui5_cl_demo_app_105.clas.abap
@@ -9,7 +9,6 @@ CLASS z2ui5_cl_demo_app_105 DEFINITION
     DATA client TYPE REF TO z2ui5_if_client .
     DATA mo_view_parent TYPE REF TO z2ui5_cl_xml_view .
     DATA mv_class_1 TYPE string .
-    DATA mv_init TYPE abap_bool .
     DATA mr_data TYPE REF TO data .
 
     METHODS on_init .
@@ -57,8 +56,7 @@ CLASS Z2UI5_CL_DEMO_APP_105 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
       RETURN.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_106.clas.abap
+++ b/src/z2ui5_cl_demo_app_106.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_106 DEFINITION
 
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
     DATA mv_value TYPE string .
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/z2ui5_cl_demo_app_108.clas.abap
+++ b/src/z2ui5_cl_demo_app_108.clas.abap
@@ -13,7 +13,6 @@ CLASS z2ui5_cl_demo_app_108 DEFINITION
         input2 TYPE string,
         input3 TYPE string,
       END OF screen .
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS z2ui5_on_rendering

--- a/src/z2ui5_cl_demo_app_112.clas.abap
+++ b/src/z2ui5_cl_demo_app_112.clas.abap
@@ -10,7 +10,6 @@ CLASS z2ui5_cl_demo_app_112 DEFINITION
     DATA client TYPE REF TO z2ui5_if_client .
     DATA mo_view_parent TYPE REF TO z2ui5_cl_xml_view .
     DATA mv_class_2 TYPE string .
-    DATA mv_init TYPE abap_bool .
     DATA mr_data TYPE REF TO data .
 
     METHODS on_init .
@@ -59,8 +58,7 @@ CLASS z2ui5_cl_demo_app_112 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
       RETURN.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_116.clas.abap
+++ b/src/z2ui5_cl_demo_app_116.clas.abap
@@ -36,7 +36,6 @@ CLASS z2ui5_cl_demo_app_116 DEFINITION
       ty_prin_nodes TYPE STANDARD TABLE OF ty_prodh_node_level2 WITH DEFAULT KEY.
 
     DATA prodh_nodes TYPE ty_prodh_nodes .
-    DATA is_initialized TYPE abap_bool .
     DATA gv_user TYPE c LENGTH 12.
     DATA gv_date TYPE d.
 
@@ -225,8 +224,7 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
 
     me->client = client.
 
-    IF is_initialized = abap_false.
-      is_initialized = abap_true.
+    IF client->check_on_init( ).
       ui5_initialize( ).
 
       DATA(lv_save_state_js) = `function saveState() {debugger;` && |\n| &&

--- a/src/z2ui5_cl_demo_app_120.clas.abap
+++ b/src/z2ui5_cl_demo_app_120.clas.abap
@@ -12,8 +12,6 @@ CLASS z2ui5_cl_demo_app_120 DEFINITION
     DATA speed TYPE string.
     DATA altitudeaccuracy TYPE string.
     DATA accuracy TYPE string.
-    DATA check_initialized TYPE abap_bool .
-
     TYPES:
       BEGIN OF ty_spot,
         tooltip       TYPE string,

--- a/src/z2ui5_cl_demo_app_121.clas.abap
+++ b/src/z2ui5_cl_demo_app_121.clas.abap
@@ -12,8 +12,6 @@ CLASS z2ui5_cl_demo_app_121 DEFINITION
     DATA speed TYPE string.
     DATA altitudeaccuracy TYPE string.
     DATA accuracy TYPE string.
-    DATA check_initialized TYPE abap_bool .
-
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.

--- a/src/z2ui5_cl_demo_app_129.clas.abap
+++ b/src/z2ui5_cl_demo_app_129.clas.abap
@@ -36,7 +36,6 @@ CLASS z2ui5_cl_demo_app_129 DEFINITION
       END OF screen .
     DATA
       mt_suggestion TYPE STANDARD TABLE OF s_suggestion_items WITH EMPTY KEY .
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS z2ui5_on_rendering

--- a/src/z2ui5_cl_demo_app_129.clas.abap
+++ b/src/z2ui5_cl_demo_app_129.clas.abap
@@ -62,9 +62,8 @@ CLASS Z2UI5_CL_DEMO_APP_129 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF check_initialized = abap_false.
+    IF client->check_on_init( ).
       lv_text = 10.
-      check_initialized = abap_true.
       z2ui5_on_init( ).
       z2ui5_on_rendering( client ).
 

--- a/src/z2ui5_cl_demo_app_132.clas.abap
+++ b/src/z2ui5_cl_demo_app_132.clas.abap
@@ -125,8 +125,7 @@ CLASS z2ui5_cl_demo_app_132 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF mv_init IS INITIAL.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       on_init( ).
 

--- a/src/z2ui5_cl_demo_app_132.clas.abap
+++ b/src/z2ui5_cl_demo_app_132.clas.abap
@@ -8,8 +8,6 @@ CLASS z2ui5_cl_demo_app_132 DEFINITION
     DATA mv_view_display TYPE abap_bool.
     DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
     DATA mv_perc         TYPE string.
-    DATA mv_init         TYPE abap_bool.
-
     METHODS set_app_data
       IMPORTING
         !count TYPE string

--- a/src/z2ui5_cl_demo_app_140.clas.abap
+++ b/src/z2ui5_cl_demo_app_140.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_demo_app_140 DEFINITION
       ty_t_combo TYPE STANDARD TABLE OF s_combobox WITH EMPTY KEY .
 
     DATA client TYPE REF TO z2ui5_if_client .
-    DATA check_initialized TYPE abap_bool .
     DATA gt_multi TYPE ty_t_combo.
     DATA gt_sel_multi TYPE ty_t_combo.
     DATA gt_sel_multi2 TYPE string_table.

--- a/src/z2ui5_cl_demo_app_143.clas.abap
+++ b/src/z2ui5_cl_demo_app_143.clas.abap
@@ -17,8 +17,6 @@ CLASS z2ui5_cl_demo_app_143 DEFINITION
 
     DATA gt_data TYPE ty_t_data.
     DATA client TYPE REF TO z2ui5_if_client .
-    DATA check_initialized TYPE abap_bool .
-
     METHODS ui5_on_init .
     METHODS ui5_on_event .
     METHODS ui5_view_main_display .

--- a/src/z2ui5_cl_demo_app_152.clas.abap
+++ b/src/z2ui5_cl_demo_app_152.clas.abap
@@ -14,8 +14,6 @@ CLASS z2ui5_cl_demo_app_152 DEFINITION PUBLIC.
         descr   TYPE string,
       END OF ty_row.
     DATA mt_tab TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY.
-
-    DATA mv_check_initialized TYPE abap_bool.
     DATA mv_multiselect TYPE abap_bool.
     DATA mv_preselect TYPE abap_bool.
     METHODS ui5_display.
@@ -105,8 +103,7 @@ CLASS z2ui5_cl_demo_app_152 IMPLEMENTATION.
     me->client = client.
 
     IF client->get( )-check_on_navigated = abap_true.
-      IF mv_check_initialized = abap_false.
-        mv_check_initialized = abap_true.
+      IF client->check_on_init( ).
         ui5_display( ).
       ELSE.
         ui5_callback( ).

--- a/src/z2ui5_cl_demo_app_160.clas.abap
+++ b/src/z2ui5_cl_demo_app_160.clas.abap
@@ -38,8 +38,6 @@ CLASS z2ui5_cl_demo_app_160 DEFINITION
         pl_q04         TYPE i,
         per_cent_q04   TYPE p LENGTH 2 DECIMALS 1,
       END OF s_output .
-
-    DATA check_initialized TYPE abap_bool .
     DATA mt_output TYPE STANDARD TABLE OF s_output.
     DATA client TYPE REF TO z2ui5_if_client.
 

--- a/src/z2ui5_cl_demo_app_162.clas.abap
+++ b/src/z2ui5_cl_demo_app_162.clas.abap
@@ -20,7 +20,6 @@ CLASS z2ui5_cl_demo_app_162 DEFINITION PUBLIC.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA mv_check_initialized TYPE abap_bool.
     METHODS on_event.
     METHODS view_display.
     METHODS set_data.
@@ -116,8 +115,7 @@ CLASS z2ui5_cl_demo_app_162 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_check_initialized = abap_false.
-      mv_check_initialized = abap_true.
+    IF client->check_on_init( ).
       mt_filter = z2ui5_cl_util=>filter_get_multi_by_data( mt_table ).
       DELETE mt_filter WHERE name = `SELKZ`.
       view_display( ).

--- a/src/z2ui5_cl_demo_app_163.clas.abap
+++ b/src/z2ui5_cl_demo_app_163.clas.abap
@@ -9,7 +9,6 @@ CLASS z2ui5_cl_demo_app_163 DEFINITION
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA mv_check_initialized TYPE abap_bool.
     METHODS on_event.
     METHODS view_display.
     METHODS view_action_sheet.
@@ -94,8 +93,7 @@ CLASS Z2UI5_CL_DEMO_APP_163 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_check_initialized = abap_false.
-      mv_check_initialized = abap_true.
+    IF client->check_on_init( ).
       view_display( ).
       RETURN.
     ENDIF.

--- a/src/z2ui5_cl_demo_app_164.clas.abap
+++ b/src/z2ui5_cl_demo_app_164.clas.abap
@@ -19,7 +19,6 @@ CLASS z2ui5_cl_demo_app_164 DEFINITION PUBLIC.
 
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA mv_check_initialized TYPE abap_bool.
     METHODS on_event.
     METHODS view_display.
     METHODS set_data.
@@ -105,8 +104,7 @@ CLASS z2ui5_cl_demo_app_164 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_check_initialized = abap_false.
-      mv_check_initialized = abap_true.
+    IF client->check_on_init( ).
       set_data( ).
       view_display( ).
       RETURN.

--- a/src/z2ui5_cl_demo_app_172.clas.abap
+++ b/src/z2ui5_cl_demo_app_172.clas.abap
@@ -20,8 +20,6 @@ CLASS z2ui5_cl_demo_app_172 DEFINITION
         bool     TYPE abap_bool,
         waers    TYPE waers,
       END OF ty_output .
-
-    DATA check_initialized TYPE abap_bool .
     DATA output TYPE STANDARD TABLE OF ty_output.
     DATA client TYPE REF TO z2ui5_if_client.
   PROTECTED SECTION.

--- a/src/z2ui5_cl_demo_app_173.clas.abap
+++ b/src/z2ui5_cl_demo_app_173.clas.abap
@@ -23,8 +23,6 @@ CLASS z2ui5_cl_demo_app_173 DEFINITION
       ty_t_layout TYPE STANDARD TABLE OF ty_s_layout WITH EMPTY KEY.
 
     DATA mv_flag TYPE abap_bool. " VALUE abap_true.
-    DATA mv_initialized TYPE abap_bool.
-
     DATA mt_layout TYPE ty_t_layout.
     DATA mt_data   TYPE ty_t_data.
 
@@ -88,8 +86,7 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_initialized = abap_false.
-      mv_initialized = abap_true.
+    IF client->check_on_init( ).
 
       client->_bind( mt_layout ).
 

--- a/src/z2ui5_cl_demo_app_178.clas.abap
+++ b/src/z2ui5_cl_demo_app_178.clas.abap
@@ -32,8 +32,6 @@ CLASS z2ui5_cl_demo_app_178 DEFINITION
       ty_prodh_nodes TYPE STANDARD TABLE OF ty_prodh_node_level1 WITH DEFAULT KEY .
 
     DATA prodh_nodes TYPE ty_prodh_nodes .
-    DATA is_initialized TYPE abap_bool .
-
     METHODS ui5_display_view .
   PROTECTED SECTION.
 
@@ -145,8 +143,7 @@ CLASS z2ui5_cl_demo_app_178 IMPLEMENTATION.
 
     me->client = client.
 
-    IF is_initialized = abap_false.
-      is_initialized = abap_true.
+    IF client->check_on_init( ).
       ui5_initialize( ).
       ui5_display_view( ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_179.clas.abap
+++ b/src/z2ui5_cl_demo_app_179.clas.abap
@@ -28,8 +28,6 @@ CLASS z2ui5_cl_demo_app_179 DEFINITION
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client .
-    DATA check_initialized TYPE abap_bool .
-
     METHODS set_view .
     METHODS z2ui5_on_event .
     METHODS set_mock_data .

--- a/src/z2ui5_cl_demo_app_180.clas.abap
+++ b/src/z2ui5_cl_demo_app_180.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_180 DEFINITION
 
 
     INTERFACES z2ui5_if_app .
-
-    DATA mv_initialized TYPE abap_bool.
     DATA mv_url TYPE string.
 
     METHODS on_event.
@@ -66,8 +64,7 @@ CLASS Z2UI5_CL_DEMO_APP_180 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_initialized = abap_false.
-      mv_initialized = abap_true.
+    IF client->check_on_init( ).
       view_display( ).
     ENDIF.
 

--- a/src/z2ui5_cl_demo_app_181.clas.abap
+++ b/src/z2ui5_cl_demo_app_181.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_181 DEFINITION
 
 
     INTERFACES z2ui5_if_app .
-
-    DATA mv_initialized TYPE abap_bool .
     DATA mv_url TYPE string .
 
     TYPES:
@@ -146,8 +144,7 @@ CLASS z2ui5_cl_demo_app_181 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_initialized = abap_false.
-      mv_initialized = abap_true.
+    IF client->check_on_init( ).
 
       view_display( ).
 

--- a/src/z2ui5_cl_demo_app_182.clas.abap
+++ b/src/z2ui5_cl_demo_app_182.clas.abap
@@ -34,8 +34,6 @@ CLASS z2ui5_cl_demo_app_182 DEFINITION
              nodes TYPE tt_nodes2,
              lines TYPE tt_lines4,
            END OF t_json1.
-
-    DATA mv_initialized TYPE abap_bool .
     DATA mt_data TYPE t_json1 .
 
     METHODS on_event .
@@ -199,8 +197,7 @@ CLASS Z2UI5_CL_DEMO_APP_182 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_initialized = abap_false.
-      mv_initialized = abap_true.
+    IF client->check_on_init( ).
 
       mt_data = VALUE #( nodes             = VALUE #( ( id = `Dinter`
                                             title          = `Sophie Dinter`

--- a/src/z2ui5_cl_demo_app_183.clas.abap
+++ b/src/z2ui5_cl_demo_app_183.clas.abap
@@ -20,7 +20,6 @@ CLASS z2ui5_cl_demo_app_183 DEFINITION
 
     DATA
       t_tab TYPE STANDARD TABLE OF ty_row WITH EMPTY KEY .
-    DATA check_initialized TYPE abap_bool .
     DATA check_ui5 TYPE abap_bool .
     DATA mv_key TYPE string .
     DATA sortorder TYPE string VALUE `None`.

--- a/src/z2ui5_cl_demo_app_184.clas.abap
+++ b/src/z2ui5_cl_demo_app_184.clas.abap
@@ -11,8 +11,6 @@ CLASS z2ui5_cl_demo_app_184 DEFINITION
     DATA mv_table        TYPE string.
     DATA mt_table        TYPE REF TO data.
     DATA mt_table_tmp    TYPE REF TO data.
-    DATA mv_init TYPE abap_bool.
-
     DATA mt_comp         TYPE abap_component_tab.
 
     METHODS set_app_data
@@ -104,8 +102,7 @@ CLASS z2ui5_cl_demo_app_184 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       on_init( ).
 

--- a/src/z2ui5_cl_demo_app_186.clas.abap
+++ b/src/z2ui5_cl_demo_app_186.clas.abap
@@ -7,8 +7,6 @@ CLASS z2ui5_cl_demo_app_186 DEFINITION
 
 
     INTERFACES z2ui5_if_app .
-
-    DATA is_initialized TYPE abap_bool .
     DATA file_content_64 TYPE string .
     DATA file_name TYPE string .
     DATA mime_type TYPE string .

--- a/src/z2ui5_cl_demo_app_186.clas.abap
+++ b/src/z2ui5_cl_demo_app_186.clas.abap
@@ -106,11 +106,10 @@ CLASS Z2UI5_CL_DEMO_APP_186 IMPLEMENTATION.
 
     me->client = client.
 
-    IF is_initialized = abap_false.
+    IF client->check_on_init( ).
 
       initialize( ).
       render_screen( ).
-      is_initialized = abap_true.
 
     ENDIF.
 

--- a/src/z2ui5_cl_demo_app_189.clas.abap
+++ b/src/z2ui5_cl_demo_app_189.clas.abap
@@ -14,7 +14,6 @@ CLASS z2ui5_cl_demo_app_189 DEFINITION
       focus_field TYPE string.
 
   PRIVATE SECTION.
-    DATA initialized TYPE abap_bool.
     DATA client TYPE REF TO z2ui5_if_client.
 
     METHODS render.
@@ -71,8 +70,7 @@ CLASS z2ui5_cl_demo_app_189 IMPLEMENTATION.
 
     me->client = client.
 
-    IF initialized = abap_false.
-      initialized = abap_true.
+    IF client->check_on_init( ).
       focus_field = 'IdOne'.
       render( ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_190.clas.abap
+++ b/src/z2ui5_cl_demo_app_190.clas.abap
@@ -11,9 +11,6 @@ CLASS z2ui5_cl_demo_app_190 DEFINITION
     DATA mv_table        TYPE string.
     DATA mt_table        TYPE REF TO data.
     DATA mt_comp         TYPE abap_component_tab.
-
-    DATA mv_init TYPE abap_bool.
-
     METHODS set_app_data
       IMPORTING !count TYPE string
                 !table TYPE string.
@@ -111,8 +108,7 @@ CLASS z2ui5_cl_demo_app_190 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
       on_init( ).
 
     ENDIF.

--- a/src/z2ui5_cl_demo_app_194.clas.abap
+++ b/src/z2ui5_cl_demo_app_194.clas.abap
@@ -14,8 +14,6 @@ CLASS z2ui5_cl_demo_app_194 DEFINITION
     DATA ms_table_row    TYPE REF TO data.
     DATA mt_comp         TYPE abap_component_tab.
     DATA ms_fixval       TYPE REF TO data.
-    DATA mv_init         TYPE abap_bool.
-
     METHODS set_app_data
       IMPORTING
         !table TYPE string.
@@ -129,8 +127,7 @@ CLASS z2ui5_cl_demo_app_194 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
     me->client = client.
 
-    IF mv_init = abap_false.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       on_init( ).
 

--- a/src/z2ui5_cl_demo_app_196.clas.abap
+++ b/src/z2ui5_cl_demo_app_196.clas.abap
@@ -178,11 +178,10 @@ CLASS Z2UI5_CL_DEMO_APP_196 IMPLEMENTATION.
 
     me->client = client.
 
-    IF is_initialized = abap_false.
+    IF client->check_on_init( ).
 
       initialize( ).
       render_screen( ).
-      is_initialized = abap_true.
 
     ENDIF.
 

--- a/src/z2ui5_cl_demo_app_196.clas.abap
+++ b/src/z2ui5_cl_demo_app_196.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_196 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA is_initialized TYPE abap_bool .
     DATA mv_slider_value TYPE i .
 
     TYPES: BEGIN OF ty_shape,

--- a/src/z2ui5_cl_demo_app_197.clas.abap
+++ b/src/z2ui5_cl_demo_app_197.clas.abap
@@ -21,7 +21,6 @@ CLASS z2ui5_cl_demo_app_197 DEFINITION
     DATA mt_table TYPE ty_t_table .
     DATA mt_table_full TYPE ty_t_table .
     DATA mt_table_products TYPE ty_t_table .
-    DATA check_initialized TYPE abap_bool .
     DATA client TYPE REF TO z2ui5_if_client .
     DATA mv_check_popover TYPE abap_bool .
     DATA mv_product TYPE string .

--- a/src/z2ui5_cl_demo_app_205.clas.abap
+++ b/src/z2ui5_cl_demo_app_205.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_205 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_206.clas.abap
+++ b/src/z2ui5_cl_demo_app_206.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_206 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_207.clas.abap
+++ b/src/z2ui5_cl_demo_app_207.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_207 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_208.clas.abap
+++ b/src/z2ui5_cl_demo_app_208.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_208 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_209.clas.abap
+++ b/src/z2ui5_cl_demo_app_209.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_209 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_210.clas.abap
+++ b/src/z2ui5_cl_demo_app_210.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_210 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_213.clas.abap
+++ b/src/z2ui5_cl_demo_app_213.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_213 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_214.clas.abap
+++ b/src/z2ui5_cl_demo_app_214.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_214 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_215.clas.abap
+++ b/src/z2ui5_cl_demo_app_215.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_215 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_216.clas.abap
+++ b/src/z2ui5_cl_demo_app_216.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_216 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_217.clas.abap
+++ b/src/z2ui5_cl_demo_app_217.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_217 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_218.clas.abap
+++ b/src/z2ui5_cl_demo_app_218.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_218 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_219.clas.abap
+++ b/src/z2ui5_cl_demo_app_219.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_219 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_220.clas.abap
+++ b/src/z2ui5_cl_demo_app_220.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_220 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_221.clas.abap
+++ b/src/z2ui5_cl_demo_app_221.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_221 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_222.clas.abap
+++ b/src/z2ui5_cl_demo_app_222.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_222 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_223.clas.abap
+++ b/src/z2ui5_cl_demo_app_223.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_223 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_224.clas.abap
+++ b/src/z2ui5_cl_demo_app_224.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_224 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_225.clas.abap
+++ b/src/z2ui5_cl_demo_app_225.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_225 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_226.clas.abap
+++ b/src/z2ui5_cl_demo_app_226.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_226 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_227.clas.abap
+++ b/src/z2ui5_cl_demo_app_227.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_227 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_228.clas.abap
+++ b/src/z2ui5_cl_demo_app_228.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_228 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_229.clas.abap
+++ b/src/z2ui5_cl_demo_app_229.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_229 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_230.clas.abap
+++ b/src/z2ui5_cl_demo_app_230.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_230 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_231.clas.abap
+++ b/src/z2ui5_cl_demo_app_231.clas.abap
@@ -24,9 +24,6 @@ CLASS z2ui5_cl_demo_app_231 DEFINITION
       text    TYPE string.
 
   PRIVATE SECTION.
-    DATA
-      check_initialized TYPE abap_bool.
-
     METHODS:
       display_view
         IMPORTING

--- a/src/z2ui5_cl_demo_app_232.clas.abap
+++ b/src/z2ui5_cl_demo_app_232.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_232 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_233.clas.abap
+++ b/src/z2ui5_cl_demo_app_233.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_233 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_234.clas.abap
+++ b/src/z2ui5_cl_demo_app_234.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_234 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_235.clas.abap
+++ b/src/z2ui5_cl_demo_app_235.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_235 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_236.clas.abap
+++ b/src/z2ui5_cl_demo_app_236.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_236 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_237.clas.abap
+++ b/src/z2ui5_cl_demo_app_237.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_237 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_238.clas.abap
+++ b/src/z2ui5_cl_demo_app_238.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_238 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_239.clas.abap
+++ b/src/z2ui5_cl_demo_app_239.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_239 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_240.clas.abap
+++ b/src/z2ui5_cl_demo_app_240.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_240 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_241.clas.abap
+++ b/src/z2ui5_cl_demo_app_241.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_241 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_242.clas.abap
+++ b/src/z2ui5_cl_demo_app_242.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_242 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_243.clas.abap
+++ b/src/z2ui5_cl_demo_app_243.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_243 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     METHODS display_view

--- a/src/z2ui5_cl_demo_app_244.clas.abap
+++ b/src/z2ui5_cl_demo_app_244.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_244 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_245.clas.abap
+++ b/src/z2ui5_cl_demo_app_245.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_245 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_246.clas.abap
+++ b/src/z2ui5_cl_demo_app_246.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_246 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_247.clas.abap
+++ b/src/z2ui5_cl_demo_app_247.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_247 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_248.clas.abap
+++ b/src/z2ui5_cl_demo_app_248.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_248 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_249.clas.abap
+++ b/src/z2ui5_cl_demo_app_249.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_249 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_250.clas.abap
+++ b/src/z2ui5_cl_demo_app_250.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_250 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_251.clas.abap
+++ b/src/z2ui5_cl_demo_app_251.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_251 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_252.clas.abap
+++ b/src/z2ui5_cl_demo_app_252.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_252 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_253.clas.abap
+++ b/src/z2ui5_cl_demo_app_253.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_253 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_254.clas.abap
+++ b/src/z2ui5_cl_demo_app_254.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_254 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_255.clas.abap
+++ b/src/z2ui5_cl_demo_app_255.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_255 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_256.clas.abap
+++ b/src/z2ui5_cl_demo_app_256.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_256 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_257.clas.abap
+++ b/src/z2ui5_cl_demo_app_257.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_257 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_258.clas.abap
+++ b/src/z2ui5_cl_demo_app_258.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_258 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
     DATA selected_menu_entry TYPE string .
   PROTECTED SECTION.
 

--- a/src/z2ui5_cl_demo_app_260.clas.abap
+++ b/src/z2ui5_cl_demo_app_260.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_260 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_261.clas.abap
+++ b/src/z2ui5_cl_demo_app_261.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_261 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_262.clas.abap
+++ b/src/z2ui5_cl_demo_app_262.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_262 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_263.clas.abap
+++ b/src/z2ui5_cl_demo_app_263.clas.abap
@@ -5,8 +5,6 @@ CLASS z2ui5_cl_demo_app_263 DEFINITION
   PUBLIC SECTION.
 
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_264.clas.abap
+++ b/src/z2ui5_cl_demo_app_264.clas.abap
@@ -16,7 +16,6 @@ CLASS z2ui5_cl_demo_app_264 DEFINITION
       lt_a_data TYPE STANDARD TABLE OF ty_a_data .
     DATA ls_a_data TYPE ty_a_data .
     DATA s_text TYPE string .
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.

--- a/src/z2ui5_cl_demo_app_279.clas.abap
+++ b/src/z2ui5_cl_demo_app_279.clas.abap
@@ -12,8 +12,6 @@ CLASS z2ui5_cl_demo_app_279 DEFINITION
 
   PRIVATE SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-    DATA initialized TYPE abap_bool.
-
     METHODS display_view.
     METHODS on_event.
     METHODS security_check_popup.
@@ -112,8 +110,7 @@ CLASS z2ui5_cl_demo_app_279 IMPLEMENTATION.
 
     on_event( ).
 
-    IF initialized = abap_false.
-      initialized = abap_true.
+    IF client->check_on_init( ).
       display_view( ).
     ELSE.
       client->view_model_update( ).

--- a/src/z2ui5_cl_demo_app_309.clas.abap
+++ b/src/z2ui5_cl_demo_app_309.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_309 DEFINITION
 
 
     INTERFACES z2ui5_if_app .
-
-    DATA mv_initialized TYPE abap_bool.
     DATA mv_url TYPE string.
 
     METHODS on_event.
@@ -68,8 +66,7 @@ CLASS Z2UI5_CL_DEMO_APP_309 IMPLEMENTATION.
 
     me->client = client.
 
-    IF mv_initialized = abap_false.
-      mv_initialized = abap_true.
+    IF client->check_on_init( ).
 
       view_display( ).
 

--- a/src/z2ui5_cl_demo_app_330.clas.abap
+++ b/src/z2ui5_cl_demo_app_330.clas.abap
@@ -6,8 +6,6 @@ CLASS z2ui5_cl_demo_app_330 DEFINITION
 
     INTERFACES if_serializable_object .
     INTERFACES z2ui5_if_app .
-
-    DATA check_initialized TYPE abap_bool .
   PROTECTED SECTION.
 
     DATA client TYPE REF TO z2ui5_if_client.
@@ -358,8 +356,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
 
     me->client = client.
 
-    IF check_initialized = abap_false.
-      check_initialized = abap_true.
+    IF client->check_on_init( ).
       display_view( client ).
 
     ENDIF.

--- a/src/z2ui5_cl_demo_app_339.clas.abap
+++ b/src/z2ui5_cl_demo_app_339.clas.abap
@@ -166,8 +166,7 @@ CLASS z2ui5_cl_demo_app_339 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF mv_init IS INITIAL.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       get_data( ).
 

--- a/src/z2ui5_cl_demo_app_339.clas.abap
+++ b/src/z2ui5_cl_demo_app_339.clas.abap
@@ -7,7 +7,6 @@ CLASS z2ui5_cl_demo_app_339 DEFINITION
 
     DATA mv_view_display TYPE abap_bool.
     DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
-    DATA mv_init         TYPE abap_bool.
     DATA mv_table        TYPE string.
 
     DATA mt_table_tmp    TYPE REF TO data.

--- a/src/z2ui5_cl_demo_app_340.clas.abap
+++ b/src/z2ui5_cl_demo_app_340.clas.abap
@@ -68,8 +68,7 @@ CLASS z2ui5_cl_demo_app_340 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF mv_init IS INITIAL.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       render_main( client ).
 

--- a/src/z2ui5_cl_demo_app_340.clas.abap
+++ b/src/z2ui5_cl_demo_app_340.clas.abap
@@ -4,8 +4,6 @@ CLASS z2ui5_cl_demo_app_340 DEFINITION
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
-
-    DATA mv_init     TYPE abap_bool.
     DATA mt_data_tmp TYPE REF TO data.
     DATA mt_data     TYPE REF TO data.
     DATA ms_data_row TYPE REF TO data.

--- a/src/z2ui5_cl_demo_app_342.clas.abap
+++ b/src/z2ui5_cl_demo_app_342.clas.abap
@@ -167,8 +167,7 @@ CLASS z2ui5_cl_demo_app_342 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF mv_init IS INITIAL.
-      mv_init = abap_true.
+    IF client->check_on_init( ).
 
       get_data( ).
 

--- a/src/z2ui5_cl_demo_app_342.clas.abap
+++ b/src/z2ui5_cl_demo_app_342.clas.abap
@@ -7,7 +7,6 @@ CLASS z2ui5_cl_demo_app_342 DEFINITION
 
     DATA mv_view_display TYPE abap_bool.
     DATA mo_parent_view  TYPE REF TO z2ui5_cl_xml_view.
-    DATA mv_init         TYPE abap_bool.
     DATA mv_table        TYPE string.
 
     DATA mt_data_tmp    TYPE REF TO data.

--- a/src/z2ui5_cl_demo_app_350.clas.abap
+++ b/src/z2ui5_cl_demo_app_350.clas.abap
@@ -4,7 +4,6 @@ CLASS z2ui5_cl_demo_app_350 DEFINITION
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
-    DATA check_initialized TYPE abap_bool.
     DATA: view_id TYPE i.
     DATA text TYPE string VALUE 'call booking mask'.
     DATA varkey TYPE char120.
@@ -62,8 +61,7 @@ CLASS z2ui5_cl_demo_app_350 IMPLEMENTATION.
 
     ELSEIF view_id = 2.
       TRY.
-          IF check_initialized = abap_false.
-            check_initialized = abap_true.
+          IF client->check_on_init( ).
 
             DATA(lv_fm) = 'ENQUEUE_E_TABLE'.
             CALL FUNCTION lv_fm

--- a/src/z2ui5_cl_demo_app_351.clas.locals_imp.abap
+++ b/src/z2ui5_cl_demo_app_351.clas.locals_imp.abap
@@ -11,7 +11,6 @@ ENDCLASS.
 
 CLASS zcl_2ui5_lock DEFINITION INHERITING FROM z2ui5_cl_demo_app_351.
   PUBLIC SECTION.
-    DATA check_initialized TYPE abap_bool.
     DATA varkey TYPE char120.
     METHODS z2ui5_if_app~main                       REDEFINITION.
   PROTECTED SECTION.
@@ -91,8 +90,7 @@ CLASS zcl_2ui5_lock IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
     TRY.
-        IF check_initialized = abap_false.
-          check_initialized = abap_true.
+        IF client->check_on_init( ).
           set_session_stateful( client   = client
                                 stateful = abap_true ).
           DATA(lv_fm) = 'ENQUEUE_E_TABLE'.

--- a/src/z2ui5_cl_demo_app_353.clas.abap
+++ b/src/z2ui5_cl_demo_app_353.clas.abap
@@ -24,7 +24,6 @@ CLASS z2ui5_cl_demo_app_353 DEFINITION
     DATA device_width      TYPE string.
 
   PRIVATE SECTION.
-    DATA initialized TYPE abap_bool.
     DATA client      TYPE REF TO z2ui5_if_client.
 
     METHODS render.
@@ -102,8 +101,7 @@ CLASS z2ui5_cl_demo_app_353 IMPLEMENTATION.
 
     me->client = client.
 
-    IF initialized = abap_false.
-      initialized = abap_true.
+    IF client->check_on_init( ).
       focus_field = 'IdOne'.
       mv_check_active = abap_true.
       render( ).


### PR DESCRIPTION
## Summary
This PR refactors initialization logic across 60+ demo application classes by replacing manual boolean initialization flags with a centralized `client->check_on_init()` method call. This improves code consistency, reduces boilerplate, and delegates initialization state management to the client interface.

## Key Changes
- **Removed manual initialization flags**: Deleted instance variables like `mv_init`, `initialized`, `check_initialized`, `is_initialized`, and `mv_check_initialized` from class definitions
- **Replaced initialization checks**: Changed all manual flag-based initialization patterns from:
  ```abap
  IF mv_init = abap_false.
    mv_init = abap_true.
    on_init( ).
  ENDIF.
  ```
  to:
  ```abap
  IF client->check_on_init( ).
    on_init( ).
  ENDIF.
  ```
- **Applied consistently across demo apps**: Updated 60+ demo application classes (z2ui5_cl_demo_app_*) to use the new pattern
- **Removed unnecessary blank lines**: Cleaned up formatting by removing extra blank lines around removed variable declarations

## Implementation Details
- The `client->check_on_init()` method encapsulates the initialization state tracking, eliminating the need for each class to maintain its own initialization flag
- This change centralizes initialization logic management at the client level, making it easier to modify initialization behavior globally
- All initialization logic remains functionally equivalent; only the mechanism for tracking initialization state has changed
- The refactoring maintains backward compatibility as the client interface handles the state management internally

https://claude.ai/code/session_011FQby5hPCKsx3MvpBzHVAP