### PR TITLE
Refactor method calls to use positional parameters

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -22,6 +22,8 @@
     "errorNamespace": "."
   },
   "rules": {
+    "exporting": true,
+    "omit_parameter_name": true,
     "downport": true,
     "begin_end_names": true,
     "check_ddic": true,

--- a/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
+++ b/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
@@ -28,7 +28,7 @@ CLASS Z2UI5_CL_DEMO_APP_LP_02 IMPLEMENTATION.
         DATA(page) = shell->page( showheader = abap_false ).
         page->_z2ui5( )->lp_title( client->_bind_edit( mv_title ) ).
       ELSE.
-        page = shell->page( title = client->_bind_edit( mv_title ) ).
+        page = shell->page( client->_bind_edit( mv_title ) ).
       ENDIF.
 
       client->view_display( page->simple_form( title    = 'Set Launchpad Title Dynamically'

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -46,7 +46,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
   METHOD display_view.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( val = view->shell(
+    client->view_display( view->shell(
            )->page(
                    title          = 'abap2UI5 - First Example'
                    navbuttonpress = client->_event_nav_app_leave( )
@@ -69,7 +69,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
   METHOD on_event.
 
     IF client->check_on_event( 'BUTTON_POST' ).
-      client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
+      client->message_toast_display( |{ product } { quantity } - send to the server| ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/z2ui5_cl_demo_app_002.clas.abap
+++ b/src/z2ui5_cl_demo_app_002.clas.abap
@@ -200,7 +200,7 @@ CLASS z2ui5_cl_demo_app_002 IMPLEMENTATION.
       )->get_parent( )->get_parent( ).
 
     lv_test->label( 'Segmented Button'
-      )->segmented_button( selected_key = client->_bind_edit( screen-segment_key )
+      )->segmented_button( client->_bind_edit( screen-segment_key )
         )->items(
             )->segmented_button_item(
                 key  = 'BLUE'

--- a/src/z2ui5_cl_demo_app_006.clas.abap
+++ b/src/z2ui5_cl_demo_app_006.clas.abap
@@ -85,7 +85,7 @@ CLASS z2ui5_cl_demo_app_006 IMPLEMENTATION.
                 text  = 'letf side button'
                 icon  = 'sap-icon://account'
                 press = client->_event( 'BUTTON_SORT' )
-            )->segmented_button( selected_key = mv_key
+            )->segmented_button( mv_key
                 )->items(
                     )->segmented_button_item(
                         key  = 'BLUE'

--- a/src/z2ui5_cl_demo_app_014.clas.abap
+++ b/src/z2ui5_cl_demo_app_014.clas.abap
@@ -119,7 +119,7 @@ CLASS Z2UI5_CL_DEMO_APP_014 IMPLEMENTATION.
                                       displayedvalue = '9.9%' ).
 
     point = grid->vertical_layout(
-        )->layout_data( ns = 'layout'
+        )->layout_data( 'layout'
             )->grid_data( 'XL12 L12 M12 S12'
         )->get_parent(
         )->text(

--- a/src/z2ui5_cl_demo_app_017.clas.abap
+++ b/src/z2ui5_cl_demo_app_017.clas.abap
@@ -55,11 +55,11 @@ CLASS Z2UI5_CL_DEMO_APP_017 IMPLEMENTATION.
                     )->title( text     = 'Oblomov Dev'
                               wrapping = abap_true ).
 
-    header_title->expanded_content( ns = `uxap` )->text( `abap2UI5 Developer` ).
-    header_title->snapped_content( ns = `uxap` )->text( `abap2UI5 Developer` ).
+    header_title->expanded_content( `uxap` )->text( `abap2UI5 Developer` ).
+    header_title->snapped_content( `uxap` )->text( `abap2UI5 Developer` ).
     header_title->snapped_title_on_mobile( )->title( `abap2UI5 Developer` ).
 
-    header_title->actions( ns = `uxap` )->overflow_toolbar(
+    header_title->actions( `uxap` )->overflow_toolbar(
              )->overflow_toolbar_button(
                  icon    = `sap-icon://edit`
                  text    = 'edit header'
@@ -79,7 +79,7 @@ CLASS Z2UI5_CL_DEMO_APP_017 IMPLEMENTATION.
                  text  = 'Go Back'
                  press = client->_event_nav_app_leave( ) ).
 
-    DATA(header_content) = page->header_content( ns = 'uxap' ).
+    DATA(header_content) = page->header_content( 'uxap' ).
 
     header_content->flex_box( wrap = 'Wrap'
            )->avatar( src         = lcl_help=>get_avatar( )
@@ -90,11 +90,11 @@ CLASS Z2UI5_CL_DEMO_APP_017 IMPLEMENTATION.
                 )->link( text = 'email@email.com'
             )->get_parent(
             )->horizontal_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'Hello! I an abap2UI5 developer'
-                )->label( text = 'San Jose, USA'
+                )->label( 'Hello! I an abap2UI5 developer'
+                )->label( 'San Jose, USA'
             )->get_parent(
             )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'Hello! I an abap2UI5 developer'
+                )->label( 'Hello! I an abap2UI5 developer'
                 )->vbox(
                     )->label( 'Achived goals'
                     )->progress_indicator( percentvalue = '30%'
@@ -102,7 +102,7 @@ CLASS Z2UI5_CL_DEMO_APP_017 IMPLEMENTATION.
             )->get_parent( )->get_parent(
           "  )->avatar( src = lcl_help=>get_avatar( ) class = 'sapUiSmallMarginEnd' displaySize = 'layout'
             )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'San Jose, USA'
+                )->label( 'San Jose, USA'
             )->get_parent( ).
 
 
@@ -111,86 +111,86 @@ CLASS Z2UI5_CL_DEMO_APP_017 IMPLEMENTATION.
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'goalsSectionSS1'
                                    title          = '2014 Goals Plan'
-            )->heading( ns = `uxap`
-                )->message_strip( text = 'this is a message strip'
+            )->heading( `uxap`
+                )->message_strip( 'this is a message strip'
             )->get_parent(
             )->sub_sections(
                 )->object_page_sub_section( id    = 'goalssubSectionSS1'
                                             title = 'goals1'
                     )->blocks(
                           )->vbox(
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
           )->get_parent( )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'goalsSectionWS1'
                                             title = 'goals2'
                       )->blocks(
                             )->vbox(
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2' ).
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2' ).
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'PersonalSection'
                                    title          = 'Personal'
-            )->heading( ns = `uxap`
+            )->heading( `uxap`
            "     )->message_strip( text = 'this is a message strip'
             )->get_parent(
             )->sub_sections(
                 )->object_page_sub_section( id    = 'personalSectionSS1'
                                             title = 'Connect'
                     )->blocks(
-                          )->label( text = 'telefon'
-                          )->label( text = 'email'
+                          )->label( 'telefon'
+                          )->label( 'email'
                 )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'personalSectionWS2'
                                             title = 'Payment information  '
                       )->blocks(
-                          )->label( text = 'Hello! I an abap2UI5 developer'
-                          )->label( text = 'San Jose, USA' ).
+                          )->label( 'Hello! I an abap2UI5 developer'
+                          )->label( 'San Jose, USA' ).
 
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'employmentSection'
                                    title          = 'Employment'
-             )->heading( ns = `uxap`
+             )->heading( `uxap`
            "     )->message_strip( text = 'this is a message strip'
              )->get_parent(
              )->sub_sections(
                 )->object_page_sub_section( id    = 'empSectionSS1'
                                             title = 'Job information'
                     )->blocks(
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
                 )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'empSectionWS2'
                                             title = 'Employee Details '
                       )->blocks(
                             )->vbox(
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details' ).
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details' ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_026.clas.abap
+++ b/src/z2ui5_cl_demo_app_026.clas.abap
@@ -45,7 +45,7 @@ CLASS Z2UI5_CL_DEMO_APP_026 IMPLEMENTATION.
                       type  = 'Emphasized'
                 )->get_parent( )->get_parent(
             )->text( 'make an input here:'
-            )->input( value = 'abcd' ).
+            )->input( 'abcd' ).
 
     client->popover_display(
       xml   = view->stringify( )
@@ -69,7 +69,7 @@ CLASS Z2UI5_CL_DEMO_APP_026 IMPLEMENTATION.
                   )->link( text = 'Documentation UI5 Popover Control'
                            href = 'https://openui5.hana.ondemand.com/entity/sap.m.Popover'
                   )->label( 'placement'
-                  )->segmented_button( selected_key = client->_bind_edit( mv_placement )
+                  )->segmented_button( client->_bind_edit( mv_placement )
                         )->items(
                         )->segmented_button_item(
                                 key  = 'Left'

--- a/src/z2ui5_cl_demo_app_030.clas.abap
+++ b/src/z2ui5_cl_demo_app_030.clas.abap
@@ -77,15 +77,15 @@ CLASS Z2UI5_CL_DEMO_APP_030 IMPLEMENTATION.
 
     DATA(header_title) = page->title( ns = 'f' )->get( )->dynamic_page_title( ).
 
-    header_title->heading( ns = 'f' )->title( 'Header Title' ).
+    header_title->heading( 'f' )->title( 'Header Title' ).
 
     header_title->expanded_content( 'f'
-             )->label( text = 'this is a subheading' ).
+             )->label( 'this is a subheading' ).
 
-    header_title->snapped_content( ns = 'f'
-             )->label( text = 'this is a subheading' ).
+    header_title->snapped_content( 'f'
+             )->label( 'this is a subheading' ).
 
-    header_title->actions( ns = 'f' )->overflow_toolbar(
+    header_title->actions( 'f' )->overflow_toolbar(
          )->overflow_toolbar_button(
              icon    = `sap-icon://edit`
              text    = 'edit header'
@@ -113,7 +113,7 @@ CLASS Z2UI5_CL_DEMO_APP_030 IMPLEMENTATION.
             )->button( icon = 'sap-icon://decline'
                        type = 'Transparent' ).
 
-    page->header( )->dynamic_page_header( pinnable = abap_true
+    page->header( )->dynamic_page_header( abap_true
         )->horizontal_layout(
             )->vertical_layout(
                    )->object_attribute( title = 'Location'
@@ -140,7 +140,7 @@ CLASS Z2UI5_CL_DEMO_APP_030 IMPLEMENTATION.
                                         text  = '34' ).
 
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
 
     cont->list(
          headertext = 'List Ouput'
@@ -152,7 +152,7 @@ CLASS Z2UI5_CL_DEMO_APP_030 IMPLEMENTATION.
              info        = '{INFO}' ).
 
 
-    page->footer( ns = `f` )->overflow_toolbar(
+    page->footer( `f` )->overflow_toolbar(
              )->overflow_toolbar_button(
                  icon    = `sap-icon://edit`
                  text    = 'edit header'

--- a/src/z2ui5_cl_demo_app_042.clas.abap
+++ b/src/z2ui5_cl_demo_app_042.clas.abap
@@ -55,11 +55,11 @@ CLASS Z2UI5_CL_DEMO_APP_042 IMPLEMENTATION.
                     )->title( text     = 'Oblomov Dev'
                               wrapping = abap_true ).
 
-    header_title->expanded_content( ns = `uxap` )->text( `abap2UI5 Developer` ).
-    header_title->snapped_content( ns = `uxap` )->text( `abap2UI5 Developer` ).
+    header_title->expanded_content( `uxap` )->text( `abap2UI5 Developer` ).
+    header_title->snapped_content( `uxap` )->text( `abap2UI5 Developer` ).
     header_title->snapped_title_on_mobile( )->title( `abap2UI5 Developer` ).
 
-    header_title->actions( ns = `uxap` )->overflow_toolbar(
+    header_title->actions( `uxap` )->overflow_toolbar(
              )->overflow_toolbar_button(
                  icon    = `sap-icon://edit`
                  text    = 'edit header'
@@ -79,7 +79,7 @@ CLASS Z2UI5_CL_DEMO_APP_042 IMPLEMENTATION.
                  text  = 'Go Back'
                  press = client->_event_nav_app_leave( ) ).
 
-    DATA(header_content) = page->header_content( ns = 'uxap' ).
+    DATA(header_content) = page->header_content( 'uxap' ).
 
     header_content->flex_box( wrap = 'Wrap'
            )->avatar( src         = lcl_help=>get_avatar( )
@@ -90,18 +90,18 @@ CLASS Z2UI5_CL_DEMO_APP_042 IMPLEMENTATION.
                 )->link( text = 'email@email.com'
             )->get_parent(
             )->horizontal_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'Hello! I an abap2UI5 developer'
-                )->label( text = 'San Jose, USA'
+                )->label( 'Hello! I an abap2UI5 developer'
+                )->label( 'San Jose, USA'
             )->get_parent(
             )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'Hello! I an abap2UI5 developer'
+                )->label( 'Hello! I an abap2UI5 developer'
                 )->vbox(
                     )->label( 'Achived goals'
                     )->progress_indicator( percentvalue = '30%'
                                            displayvalue = '30%'
             )->get_parent( )->get_parent(
             )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-                )->label( text = 'San Jose, USA'
+                )->label( 'San Jose, USA'
             )->get_parent( ).
 
 
@@ -110,86 +110,86 @@ CLASS Z2UI5_CL_DEMO_APP_042 IMPLEMENTATION.
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'goalsSectionSS1'
                                    title          = '2014 Goals Plan'
-            )->heading( ns = `uxap`
-                )->message_strip( text = 'this is a message strip'
+            )->heading( `uxap`
+                )->message_strip( 'this is a message strip'
             )->get_parent(
             )->sub_sections(
                 )->object_page_sub_section( id    = 'goalssubSectionSS1'
                                             title = 'goals1'
                     )->blocks(
                           )->vbox(
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
-                          )->label( text = 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
+                          )->label( 'goals1'
           )->get_parent( )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'goalsSectionWS1'
                                             title = 'goals2'
                       )->blocks(
                             )->vbox(
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2'
-                          )->label( text = 'goals2').
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2'
+                          )->label( 'goals2').
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'PersonalSection'
                                    title          = 'Personal'
-            )->heading( ns = `uxap`
+            )->heading( `uxap`
            "     )->message_strip( text = 'this is a message strip'
             )->get_parent(
             )->sub_sections(
                 )->object_page_sub_section( id    = 'personalSectionSS1'
                                             title = 'Connect'
                     )->blocks(
-                          )->label( text = 'telefon'
-                          )->label( text = 'email'
+                          )->label( 'telefon'
+                          )->label( 'email'
                 )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'personalSectionWS2'
                                             title = 'Payment information  '
                       )->blocks(
-                          )->label( text = 'Hello! I an abap2UI5 developer'
-                          )->label( text = 'San Jose, USA' ).
+                          )->label( 'Hello! I an abap2UI5 developer'
+                          )->label( 'San Jose, USA' ).
 
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'employmentSection'
                                    title          = 'Employment'
-             )->heading( ns = `uxap`
+             )->heading( `uxap`
            "     )->message_strip( text = 'this is a message strip'
              )->get_parent(
              )->sub_sections(
                 )->object_page_sub_section( id    = 'empSectionSS1'
                                             title = 'Job information'
                     )->blocks(
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
-                          )->label( text = 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
+                          )->label( 'info'
                 )->get_parent( )->get_parent(
                 )->object_page_sub_section( id    = 'empSectionWS2'
                                             title = 'Employee Details '
                       )->blocks(
                             )->vbox(
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-                          )->label( text = 'details' ).
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details'
+                          )->label( 'details' ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_047.clas.abap
+++ b/src/z2ui5_cl_demo_app_047.clas.abap
@@ -62,8 +62,8 @@ CLASS z2ui5_cl_demo_app_047 IMPLEMENTATION.
              )->content( 'form'
                  )->title( 'Input'
                  )->label( 'integer'
-                 )->input( value = client->_bind_edit( int1 )
-                 )->input( value = client->_bind_edit( int2 )
+                 )->input( client->_bind_edit( int1 )
+                 )->input( client->_bind_edit( int2 )
                  )->input( enabled = abap_false
                            value   = client->_bind_edit( int_sum )
                  )->button( text  = 'calc sum'

--- a/src/z2ui5_cl_demo_app_049.clas.abap
+++ b/src/z2ui5_cl_demo_app_049.clas.abap
@@ -94,7 +94,7 @@ CLASS Z2UI5_CL_DEMO_APP_049 IMPLEMENTATION.
              shownavbutton  = client->check_app_prev_stack( ) ).
 
 
-    page->segmented_button( selected_key = client->_bind_edit( mv_key )
+    page->segmented_button( client->_bind_edit( mv_key )
         )->items(
             )->segmented_button_item(
                 key  = 'VIEW_REFRESH'

--- a/src/z2ui5_cl_demo_app_052.clas.abap
+++ b/src/z2ui5_cl_demo_app_052.clas.abap
@@ -79,16 +79,16 @@ CLASS z2ui5_cl_demo_app_052 IMPLEMENTATION.
     page = page->dynamic_page( headerexpanded = abap_true
                                headerpinned   = abap_true ).
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
     DATA(tab) = cont->table( id    = `tab`
                              items = client->_bind_edit( val = mt_table ) ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->link( id    = `link`

--- a/src/z2ui5_cl_demo_app_053.clas.abap
+++ b/src/z2ui5_cl_demo_app_053.clas.abap
@@ -88,14 +88,14 @@ CLASS z2ui5_cl_demo_app_053 IMPLEMENTATION.
         press = client->_event( `BUTTON_START` )
         type  = `Emphasized` ).
 
-    DATA(tab) = vbox->table( items = client->_bind( val = mt_table ) ).
+    DATA(tab) = vbox->table( client->_bind( val = mt_table ) ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_056.clas.abap
+++ b/src/z2ui5_cl_demo_app_056.clas.abap
@@ -100,7 +100,7 @@ CLASS z2ui5_cl_demo_app_056 IMPLEMENTATION.
                        multiinputid  = `MultiInput` ).
 
     DATA(tab) = vbox->table(
-        items = client->_bind( val = mt_table )
+        client->_bind( val = mt_table )
            )->header_toolbar(
              )->overflow_toolbar(
              )->text( `Product:`
@@ -129,11 +129,11 @@ CLASS z2ui5_cl_demo_app_056 IMPLEMENTATION.
             )->get_parent( )->get_parent( ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_057.clas.abap
+++ b/src/z2ui5_cl_demo_app_057.clas.abap
@@ -128,11 +128,11 @@ CLASS z2ui5_cl_demo_app_057 IMPLEMENTATION.
                                      headerpinned   = abap_true ).
 
     DATA(header_title) = page->title( ns = 'f' )->get( )->dynamic_page_title( ).
-    header_title->heading( ns = 'f' )->hbox( )->title( `Download CSV` ).
+    header_title->heading( 'f' )->hbox( )->title( `Download CSV` ).
     header_title->expanded_content( 'f' ).
-    header_title->snapped_content( ns = 'f' ).
+    header_title->snapped_content( 'f' ).
 
-    DATA(lo_box) = page->header( )->dynamic_page_header( pinnable = abap_true
+    DATA(lo_box) = page->header( )->dynamic_page_header( abap_true
          )->flex_box( alignitems     = `Start`
                       justifycontent = `SpaceBetween` )->flex_box( alignitems = `Start` ).
 
@@ -142,9 +142,9 @@ CLASS z2ui5_cl_demo_app_057 IMPLEMENTATION.
         press = client->_event( `BUTTON_START` )
         type  = `Emphasized` ).
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
 
-    DATA(tab) = cont->table( items = client->_bind( val = mt_table ) ).
+    DATA(tab) = cont->table( client->_bind( val = mt_table ) ).
 
     tab->header_toolbar(
             )->toolbar(
@@ -154,11 +154,11 @@ CLASS z2ui5_cl_demo_app_057 IMPLEMENTATION.
                     press = client->_event( 'BUTTON_DOWNLOAD' ) ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_058.clas.abap
+++ b/src/z2ui5_cl_demo_app_058.clas.abap
@@ -193,7 +193,7 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
 
     tab->header_toolbar(
           )->toolbar(
-              )->title( text = ms_layout-title && ` (` && shift_right( CONV string( lines( mt_table ) ) ) && `)`
+              )->title( ms_layout-title && ` (` && shift_right( CONV string( lines( mt_table ) ) ) && `)`
       )->toolbar_spacer(
               )->button(
                   icon  = 'sap-icon://save'
@@ -209,7 +209,7 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
       lo_columns->column(
             minscreenwidth = shift_right( CONV string( lv_width ) ) && `px`
             demandpopin    = abap_true
-            width          = lr_field->length )->text( text = CONV string( lr_field->title ) ).
+            width          = lr_field->length )->text( CONV string( lr_field->title ) ).
       lv_width = lv_width + 10.
     ENDLOOP.
 
@@ -223,7 +223,7 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
       IF lr_field->editable = abap_true.
         lo_cells->input( `{` && lr_field->name && `}` ).
       ELSE.
-        lo_cells->text( text = `{` && lr_field->name && `}` ).
+        lo_cells->text( `{` && lr_field->name && `}` ).
       ENDIF.
     ENDLOOP.
 
@@ -263,8 +263,8 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
                )->checkbox( client->_bind( ms_layout-check_zebra )
                )->label( 'sticky header'
                )->input( client->_bind( ms_layout-sticky_header )
-               )->label( text = `Title`
-               )->input( value = client->_bind( ms_layout-title )
+               )->label( `Title`
+               )->input( client->_bind( ms_layout-title )
                )->label( 'sel mode'
                )->combobox(
                    selectedkey = client->_bind_edit( ms_layout-selmode )
@@ -277,7 +277,7 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
                 text     = 'Columns'
                 selected = client->_bind( mv_check_columns )
        )->table(
-        items = client->_bind_edit( ms_layout-t_cols )
+        client->_bind_edit( ms_layout-t_cols )
         )->columns(
             )->column( )->text( 'Visible' )->get_parent(
             )->column( )->text( 'Name' )->get_parent(

--- a/src/z2ui5_cl_demo_app_059.clas.abap
+++ b/src/z2ui5_cl_demo_app_059.clas.abap
@@ -100,11 +100,11 @@ CLASS z2ui5_cl_demo_app_059 IMPLEMENTATION.
 
     DATA(tab) = lo_box->table( client->_bind( mt_table ) ).
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_060.clas.abap
+++ b/src/z2ui5_cl_demo_app_060.clas.abap
@@ -350,13 +350,13 @@ CLASS Z2UI5_CL_DEMO_APP_060 IMPLEMENTATION.
                  )->get( ).
 
     input->suggestion_columns(
-        )->column( )->label( text = 'Name' )->get_parent(
-        )->column( )->label( text = 'Currency' ).
+        )->column( )->label( 'Name' )->get_parent(
+        )->column( )->label( 'Currency' ).
 
     input->suggestion_rows(
         )->column_list_item(
-            )->label( text = '{CURRENCYNAME}'
-            )->label( text = '{CURRENCY}' ).
+            )->label( '{CURRENCYNAME}'
+            )->label( '{CURRENCY}' ).
 
     page->_generic( name = `script`
                     ns   = `html` )->_cc_plain_xml( `setInputFIlter()` ).

--- a/src/z2ui5_cl_demo_app_061.clas.abap
+++ b/src/z2ui5_cl_demo_app_061.clas.abap
@@ -54,9 +54,9 @@ CLASS Z2UI5_CL_DEMO_APP_061 IMPLEMENTATION.
 
     tab->items( )->column_list_item( selected = '{SELKZ}'
       )->cells(
-          )->input( value = '{ID}'
-          )->input( value = '{TIMESTAMPL}'
-          )->input( value = '{ID_PREV}' ).
+          )->input( '{ID}'
+          )->input( '{TIMESTAMPL}'
+          )->input( '{ID_PREV}' ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_065.clas.abap
+++ b/src/z2ui5_cl_demo_app_065.clas.abap
@@ -38,15 +38,15 @@ CLASS z2ui5_cl_demo_app_065 IMPLEMENTATION.
                  press = client->_event( 'MAIN' )
       )->button( text  = 'Rerender only nested view'
                  press = client->_event( 'NEST' )
-      )->input( value = client->_bind_edit( mv_input_main ) ).
+      )->input( client->_bind_edit( mv_input_main ) ).
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory(
-          )->page( title = `Nested View`
+          )->page( `Nested View`
               )->button( text  = 'event'
                          press = client->_event( 'TEST' )
               )->button( text  = `frontend event`
                          press = client->_event_client( val = client->cs_event-open_new_tab t_arg = VALUE #( ( `https://github.com/abap2UI5/abap2UI5/` ) ) )
-              )->input( value = client->_bind_edit( mv_input_nest ) ).
+              )->input( client->_bind_edit( mv_input_nest ) ).
 
     IF client->check_on_init( ).
 

--- a/src/z2ui5_cl_demo_app_067.clas.abap
+++ b/src/z2ui5_cl_demo_app_067.clas.abap
@@ -97,12 +97,12 @@ CLASS z2ui5_cl_demo_app_067 IMPLEMENTATION.
       )->link( text = 'https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue'
          href       = 'https://sapui5.hana.ondemand.com/sdk/#/api/sap.ui.model.odata.type.String%23methods/formatValue'
       )->label( 'Numeric'
-      )->input( value = client->_bind_edit( val = numeric )
+      )->input( client->_bind_edit( val = numeric )
 
       )->label( `Without leading Zeros`
 
       )->text(
-      text = |\{path : '{ client->_bind_edit(
+      |\{path : '{ client->_bind_edit(
                             val  = numeric
                             path = abap_true ) }', type : 'sap.ui.model.odata.type.String', constraints : \{  isDigitSequence : true \} \}| ).
 

--- a/src/z2ui5_cl_demo_app_069.clas.abap
+++ b/src/z2ui5_cl_demo_app_069.clas.abap
@@ -48,7 +48,7 @@ CLASS z2ui5_cl_demo_app_069 IMPLEMENTATION.
   METHOD view_display_app_01.
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = lo_view_nested->page( title = `APP_01` ).
+    DATA(page) = lo_view_nested->page( `APP_01` ).
 
     page->button( text  = 'Update this view'
                   press = client->_event( 'UPDATE_DETAIL' ) ).
@@ -65,7 +65,7 @@ CLASS z2ui5_cl_demo_app_069 IMPLEMENTATION.
   METHOD view_display_app_02.
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = lo_view_nested->page( title = `APP_02` ).
+    DATA(page) = lo_view_nested->page( `APP_02` ).
 
     page->button( text  = 'Update this view'
                   press = client->_event( 'UPDATE_DETAIL' )
@@ -107,7 +107,7 @@ CLASS z2ui5_cl_demo_app_069 IMPLEMENTATION.
     DATA(lr_master) = page->flexible_column_layout( layout = 'TwoColumnsBeginExpanded'
                                                     id     ='test' )->begin_column_pages( ).
 
-    lr_master->tree( items = client->_bind( mt_tree ) )->items(
+    lr_master->tree( client->_bind( mt_tree ) )->items(
         )->standard_tree_item(
             type  = 'Active'
             title = '{TEXT}'

--- a/src/z2ui5_cl_demo_app_070.clas.abap
+++ b/src/z2ui5_cl_demo_app_070.clas.abap
@@ -154,11 +154,11 @@ CLASS z2ui5_cl_demo_app_070 IMPLEMENTATION.
                                       headerpinned   = abap_true ).
 
     DATA(header_title) = page->title( ns = 'f' )->get( )->dynamic_page_title( ).
-    header_title->heading( ns = 'f' )->hbox( )->title( `Search Field` ).
+    header_title->heading( 'f' )->hbox( )->title( `Search Field` ).
     header_title->expanded_content( 'f' ).
-    header_title->snapped_content( ns = 'f' ).
+    header_title->snapped_content( 'f' ).
 
-    DATA(lo_box) = page->header( )->dynamic_page_header( pinnable = abap_true
+    DATA(lo_box) = page->header( )->dynamic_page_header( abap_true
          )->flex_box( alignitems     = `Start`
                       justifycontent = `SpaceBetween` )->flex_box( alignitems = `Start` ).
 
@@ -175,7 +175,7 @@ CLASS z2ui5_cl_demo_app_070 IMPLEMENTATION.
         press = client->_event( `BUTTON_START` )
         type  = `Emphasized` ).
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
 
     DATA(tab) = cont->ui_table( rows               = client->_bind( val = mt_table )
                                 editable           = abap_false
@@ -187,17 +187,17 @@ CLASS z2ui5_cl_demo_app_070 IMPLEMENTATION.
                                 sort               = client->_event( 'SORT' )
                                 filter             = client->_event( 'FILTER' )
                                 customfilter       = client->_event( 'CUSTOMFILTER' ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( text = 'Products' ).
+    tab->ui_extension( )->overflow_toolbar( )->title( 'Products' ).
     DATA(lo_columns) = tab->ui_columns( ).
-    lo_columns->ui_column( width = '4rem' )->checkbox( selected = client->_bind_edit( lv_selkz )
+    lo_columns->ui_column( '4rem' )->checkbox( selected = client->_bind_edit( lv_selkz )
                                                        enabled  = abap_true
-                                                       select   = client->_event( `SELKZ` ) )->ui_template( )->checkbox( selected = `{SELKZ}` ).
+                                                       select   = client->_event( `SELKZ` ) )->ui_template( )->checkbox( `{SELKZ}` ).
     lo_columns->ui_column( width                         = '5rem'
                            sortproperty                  = 'ROW_ID'
-                                          filterproperty = 'ROW_ID' )->text( text = `Index` )->ui_template( )->text( text = `{ROW_ID}` ).
+                                          filterproperty = 'ROW_ID' )->text( `Index` )->ui_template( )->text( `{ROW_ID}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PROCESS'
-                           filterproperty = 'PROCESS' )->text( text = `Process Indicator`
+                           filterproperty = 'PROCESS' )->text( `Process Indicator`
       )->ui_template( )->progress_indicator( class        = 'sapUiSmallMarginBottom'
                                              percentvalue = `{PROCESS}`
                                              displayvalue = '{PROCESS} %'
@@ -205,26 +205,26 @@ CLASS z2ui5_cl_demo_app_070 IMPLEMENTATION.
                                              state        = '{PROCESS_STATE}' ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PRODUCT'
-                           filterproperty = 'PRODUCT' )->text( text = `Product` )->ui_template( )->input( value    = `{PRODUCT}`
+                           filterproperty = 'PRODUCT' )->text( `Product` )->ui_template( )->input( value    = `{PRODUCT}`
                                                                                                           editable = abap_false ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'CREATE_DATE'
-                           filterproperty = 'CREATE_DATE' )->text( text = `Date` )->ui_template( )->text( text = `{CREATE_DATE}` ).
+                           filterproperty = 'CREATE_DATE' )->text( `Date` )->ui_template( )->text( `{CREATE_DATE}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'CREATE_BY'
-                           filterproperty = 'CREATE_BY')->text( text = `Name` )->ui_template( )->text( text = `{CREATE_BY}` ).
+                           filterproperty = 'CREATE_BY')->text( `Name` )->ui_template( )->text( `{CREATE_BY}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'STORAGE_LOCATION'
-                           filterproperty = 'STORAGE_LOCATION' )->text( text = `Location` )->ui_template( )->text( text = `{STORAGE_LOCATION}`).
+                           filterproperty = 'STORAGE_LOCATION' )->text( `Location` )->ui_template( )->text( `{STORAGE_LOCATION}`).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'QUANTITY'
-                           filterproperty = 'QUANTITY' )->text( text = `Quantity` )->ui_template( )->text( text = `{QUANTITY}`).
+                           filterproperty = 'QUANTITY' )->text( `Quantity` )->ui_template( )->text( `{QUANTITY}`).
     lo_columns->ui_column( width          = '6rem'
                            sortproperty   = 'MEINS'
-                           filterproperty = 'MEINS' )->text( text = `Unit` )->ui_template( )->text( text = `{MEINS}`).
+                           filterproperty = 'MEINS' )->text( `Unit` )->ui_template( )->text( `{MEINS}`).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PRICE'
-                           filterproperty = 'PRICE' )->text( text = `Price` )->ui_template( )->currency( value    = `{PRICE}`
+                           filterproperty = 'PRICE' )->text( `Price` )->ui_template( )->currency( value    = `{PRICE}`
                                                                                                          currency = `{WAERS}` ).
     lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
       )->ui_row_action_item( type = 'Navigation'

--- a/src/z2ui5_cl_demo_app_071.clas.abap
+++ b/src/z2ui5_cl_demo_app_071.clas.abap
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_demo_app_071 IMPLEMENTATION.
     ENDDO.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( val = view->shell(
+    client->view_display( view->shell(
          )->page(
                  title          = 'abap2UI5 - First Example'
                  navbuttonpress = client->_event_nav_app_leave( )

--- a/src/z2ui5_cl_demo_app_072.clas.abap
+++ b/src/z2ui5_cl_demo_app_072.clas.abap
@@ -120,7 +120,7 @@ CLASS Z2UI5_CL_DEMO_APP_072 IMPLEMENTATION.
            items          = client->_bind( mt_table ) ).
 
     tab->columns(
-        )->column( width = '12em'
+        )->column( '12em'
             )->text( 'Product' )->get_parent(
         )->column( minscreenwidth = 'Tablet'
                    demandpopin    = abap_true
@@ -143,8 +143,8 @@ CLASS Z2UI5_CL_DEMO_APP_072 IMPLEMENTATION.
            )->cells(
              )->object_identifier( text  = '{PRODUCTNAME}'
                                    title = '{PRODUCTID}' )->get_parent(
-             )->text( text = '{SUPPLIERNAME}' )->get_parent(
-             )->text( text = '{WIDTH} x {DEPTH} x {HEIGHT} {DIMUNIT}'
+             )->text( '{SUPPLIERNAME}' )->get_parent(
+             )->text( '{WIDTH} x {DEPTH} x {HEIGHT} {DIMUNIT}'
              )->object_number( number = '{MEASURE}'
                                unit   = '{UNIT}'
                                state  = '{STATE_MEASURE}'

--- a/src/z2ui5_cl_demo_app_074.clas.abap
+++ b/src/z2ui5_cl_demo_app_074.clas.abap
@@ -86,7 +86,7 @@ CLASS z2ui5_cl_demo_app_074 IMPLEMENTATION.
       ASSIGN mr_table->* TO <tab>.
 
       DATA(tab) = page->table(
-              items = COND #( WHEN mv_check_edit = abap_true THEN client->_bind_edit( <tab> ) ELSE client->_bind_edit( <tab> ) )
+              COND #( WHEN mv_check_edit = abap_true THEN client->_bind_edit( <tab> ) ELSE client->_bind_edit( <tab> ) )
           )->header_toolbar(
               )->overflow_toolbar(
                   )->title( 'CSV Content'

--- a/src/z2ui5_cl_demo_app_076.clas.abap
+++ b/src/z2ui5_cl_demo_app_076.clas.abap
@@ -103,7 +103,7 @@ CLASS Z2UI5_CL_DEMO_APP_076 IMPLEMENTATION.
       )->gantt_table(
         )->tree_table( rows = `{path: '` && client->_bind( val = mt_table path = abap_true ) && `', parameters: {arrayNames: ['CHILDREN'],numberOfExpandedLevels: 1}}`
           )->tree_columns(
-            )->tree_column( label = 'Col 1' )->tree_template( )->text( text = `{TEXT}` )->get_parent( )->get_parent( )->get_parent(
+            )->tree_column( 'Col 1' )->tree_template( )->text( `{TEXT}` )->get_parent( )->get_parent( )->get_parent(
 *            )->tree_column( label = 'Col 1' template = 'text' )->get_parent( )->get_parent(
           )->row_settings_template(
             )->gantt_row_settings( rowid   = `{ID}`

--- a/src/z2ui5_cl_demo_app_080.clas.abap
+++ b/src/z2ui5_cl_demo_app_080.clas.abap
@@ -68,7 +68,7 @@ CLASS z2ui5_cl_demo_app_080 IMPLEMENTATION.
             shownavbutton       = client->check_app_prev_stack( )
             class               = 'sapUiContentPadding' ).
 
-    DATA(lo_vbox) = page->vbox( class ='sapUiSmallMargin' ).
+    DATA(lo_vbox) = page->vbox( 'sapUiSmallMargin' ).
 
     DATA(lo_planningcalendar) = lo_vbox->planning_calendar(
                                                           startdate         = `{= Helper.DateCreateObject($` && client->_bind( lv_s_date ) && ') }'

--- a/src/z2ui5_cl_demo_app_081.clas.abap
+++ b/src/z2ui5_cl_demo_app_081.clas.abap
@@ -57,7 +57,7 @@ CLASS Z2UI5_CL_DEMO_APP_081 IMPLEMENTATION.
                       type  = 'Emphasized'
                 )->get_parent( )->get_parent(
             )->text( 'make an input here:'
-            )->input( value = 'abcd' ).
+            )->input( 'abcd' ).
 
     client->popover_display(
       xml   = view->stringify( )
@@ -104,7 +104,7 @@ CLASS Z2UI5_CL_DEMO_APP_081 IMPLEMENTATION.
                   )->link( text = 'Documentation UI5 Popover Control'
                            href = 'https://openui5.hana.ondemand.com/entity/sap.m.Popover'
                   )->label( 'placement'
-                  )->segmented_button( selected_key = client->_bind_edit( mv_placement )
+                  )->segmented_button( client->_bind_edit( mv_placement )
                         )->items(
                         )->segmented_button_item(
                                 key  = 'Left'

--- a/src/z2ui5_cl_demo_app_083.clas.abap
+++ b/src/z2ui5_cl_demo_app_083.clas.abap
@@ -201,12 +201,12 @@ CLASS z2ui5_cl_demo_app_083 IMPLEMENTATION.
     DATA(header_title) = page->title( ns = 'f'
             )->get( )->dynamic_page_title( ).
 
-    header_title->heading( ns = 'f' )->hbox(
+    header_title->heading( 'f' )->hbox(
         )->title( `Select-Option` ).
     header_title->expanded_content( 'f' ).
-    header_title->snapped_content( ns = 'f' ).
+    header_title->snapped_content( 'f' ).
 
-    DATA(lo_box) = page->header( )->dynamic_page_header( pinnable = abap_true
+    DATA(lo_box) = page->header( )->dynamic_page_header( abap_true
          )->flex_box( alignitems     = `Start`
                       justifycontent = `SpaceBetween` )->flex_box( alignitems = `Start` ).
 
@@ -301,7 +301,7 @@ CLASS z2ui5_cl_demo_app_083 IMPLEMENTATION.
                      key  = '{N}'
                      text = '{N}'
              )->get_parent(
-             )->input( value = `{LOW}`
+             )->input( `{LOW}`
              )->input( value   = `{HIGH}`
                        visible = `{= ${OPTION} === 'BT' }`
              )->button( icon  = 'sap-icon://decline'

--- a/src/z2ui5_cl_demo_app_084.clas.abap
+++ b/src/z2ui5_cl_demo_app_084.clas.abap
@@ -188,7 +188,7 @@ CLASS z2ui5_cl_demo_app_084 IMPLEMENTATION.
                         additionaltext = '{DESCR}' ).
 
     page->footer( )->overflow_toolbar(
-         )->text( text = `MessageBox Types`
+         )->text( `MessageBox Types`
          )->button(
              text  = 'Confirm'
              press = client->_event( 'BUTTON_MCONFIRM' )

--- a/src/z2ui5_cl_demo_app_085.clas.abap
+++ b/src/z2ui5_cl_demo_app_085.clas.abap
@@ -113,11 +113,11 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
                                width       = '200px'
                                icon        = 'sap-icon://home-share' ).
 
-    header_title->expanded_content( ns = `uxap` )->text( client->_bind( ls_detail-productname ) ).
-    header_title->snapped_content( ns = `uxap` )->text( client->_bind( ls_detail-productname ) ).
+    header_title->expanded_content( `uxap` )->text( client->_bind( ls_detail-productname ) ).
+    header_title->snapped_content( `uxap` )->text( client->_bind( ls_detail-productname ) ).
     header_title->snapped_title_on_mobile( )->title( client->_bind( ls_detail-productname ) ).
 
-    header_title->actions( ns = `uxap` )->overflow_toolbar(
+    header_title->actions( `uxap` )->overflow_toolbar(
          )->overflow_toolbar_button(
              icon    = `sap-icon://supplier`
              text    = 'Supplier Detail'
@@ -153,24 +153,24 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
              tooltip = 'Close Detail'
              press   = client->_event( 'ONCLOSEDETAIL' ) ).
 
-    DATA(header_content) = page->header_content( ns = 'uxap' ).
+    DATA(header_content) = page->header_content( 'uxap' ).
     header_content->flex_box( wrap = 'Wrap'
        )->avatar( src         = c_pic_url && ls_detail-pic
                   class       = 'sapUiSmallMarginEnd'
                   displaysize = 'layout'
         )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-            )->label( text = 'Dimension'
-            )->label( text = 'Weight'
-            )->label( text = 'Price'
-            )->label( text = 'Rating'
-            )->label( text = 'Achived goals'
+            )->label( 'Dimension'
+            )->label( 'Weight'
+            )->label( 'Price'
+            )->label( 'Rating'
+            )->label( 'Achived goals'
         )->get_parent(
         )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-            )->text( text = | { ls_detail-width } x { ls_detail-depth } x { ls_detail-height } { ls_detail-dimunit }|
+            )->text( | { ls_detail-width } x { ls_detail-depth } x { ls_detail-height } { ls_detail-dimunit }|
             )->object_number( number = CONV string( ls_detail-measure )
                               unit   = ls_detail-unit
                               state  = ls_detail-state_measure
-            )->text( text = |{ ls_detail-price } { ls_detail-waers } |
+            )->text( |{ ls_detail-price } { ls_detail-waers } |
 **            )->object_number( number = `{ parts: [ { path : 'PRICE' } , { path : 'WAERS' } ] } ` state = ls_detail-state_price
             )->vbox(
             )->rating_indicator( class       = 'sapUiSmallMarginBottom'
@@ -184,17 +184,17 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
                                    showvalue    = 'true'
         )->get_parent( )->get_parent(
         )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-            )->label( text = 'Supplier'
-            )->label( text = 'Country'
-            )->label( text = 'City'
-            )->label( text = 'Street'
-            )->label( text = 'Mail'
-            )->label( text = 'Phone'
+            )->label( 'Supplier'
+            )->label( 'Country'
+            )->label( 'City'
+            )->label( 'Street'
+            )->label( 'Mail'
+            )->label( 'Phone'
         )->get_parent(
         )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-            )->label( text = ls_detail_supplier-suppliername
-            )->label( text = ls_detail_supplier-country
-            )->label( text = |{ ls_detail_supplier-zipcode }-{ ls_detail_supplier-city } |
+            )->label( ls_detail_supplier-suppliername
+            )->label( ls_detail_supplier-country
+            )->label( |{ ls_detail_supplier-zipcode }-{ ls_detail_supplier-city } |
             )->link( text = ls_detail_supplier-street
                      href = |https://www.google.com/maps/search/?api=1&query={ ls_detail_supplier-street },{ ls_detail_supplier-city },{ ls_detail_supplier-country }|
              target       = '_blank'
@@ -210,7 +210,7 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'SectionDescription'
                                    title          = 'Description'
-        )->heading( ns = `uxap`
+        )->heading( `uxap`
 *            )->message_strip( text = 'this is a message strip'
         )->get_parent(
         )->sub_sections(
@@ -232,7 +232,7 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'SupplierSection'
                                    title          = 'Supplier'
-       )->heading( ns = `uxap`
+       )->heading( `uxap`
        )->get_parent(
        )->sub_sections(
            )->object_page_sub_section( id    = 'SupplierSection1'
@@ -240,41 +240,41 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
                )->blocks(
 *                     )->simple_form( layout = 'ResponsiveGridLayout' editable = 'false'
 *                     )->content(
-                     )->label( text = |Phone { ls_detail_supplier-phone }|
-                     )->label( text = |Mail  { ls_detail_supplier-email }|
+                     )->label( |Phone { ls_detail_supplier-phone }|
+                     )->label( |Mail  { ls_detail_supplier-email }|
            )->get_parent( )->get_parent( )->get_parent(
            )->object_page_sub_section( id    = 'SupplierSection2'
                                        title = 'Payment information  '
                  )->blocks(
-                     )->label( text = '20 Days Net' ).
+                     )->label( '20 Days Net' ).
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'Others'
                                    title          = 'Others'
-      )->heading( ns = `uxap`
+      )->heading( `uxap`
       )->get_parent(
       )->sub_sections(
          )->object_page_sub_section( id    = 'Others1'
                                      title = 'Information'
                 )->blocks(
                    )->vbox(
-                   )->label( text = 'info'
-                   )->label( text = 'info'
+                   )->label( 'info'
+                   )->label( 'info'
                 )->get_parent( )->get_parent( )->get_parent(
                       )->object_page_sub_section( id    = 'Others2'
                                                   title = 'Details '
                       )->blocks(
                             )->vbox(
-                          )->label( text = 'details'
-                          )->label( text = 'details'
-      )->label( text = 'details' ).
+                          )->label( 'details'
+                          )->label( 'details'
+      )->label( 'details' ).
 
 
 
     sections->object_page_section( titleuppercase = abap_false
                                    id             = 'OtherSuppliers'
                                    title          = 'Other Supplier'
-      )->heading( ns = `uxap`
+      )->heading( `uxap`
       )->get_parent(
       )->sub_sections(
        )->object_page_sub_section( id    = 'OtherSupplier1'
@@ -302,9 +302,9 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
         )->column_list_item( type  = 'Navigation'
                              press = client->_event( val = `ONPRESSSUPPLIER` t_arg = VALUE #( ( `${SUPPLIERNAME}` ) ) )
            )->cells(
-             )->text( text = '{SUPPLIERNAME}' )->get_parent(
-             )->text( text = '{COUNTRY}'
-             )->text( text = '{CITY}' ).
+             )->text( '{SUPPLIERNAME}' )->get_parent(
+             )->text( '{COUNTRY}'
+             )->text( '{CITY}' ).
 
 
     check_detail_active = abap_true.
@@ -354,7 +354,7 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
                                       press = client->_event( 'ONSORT' ) ).
 
     tab->columns(
-        )->column( width = '12em'
+        )->column( '12em'
             )->text( 'Product' )->get_parent(
         )->column( minscreenwidth = 'Tablet'
                    demandpopin    = abap_true
@@ -376,8 +376,8 @@ CLASS Z2UI5_CL_DEMO_APP_085 IMPLEMENTATION.
            )->cells(
              )->object_identifier( text  = '{PRODUCTNAME}'
                                    title = '{PRODUCTID}' )->get_parent(
-             )->text( text = '{SUPPLIERNAME}' )->get_parent(
-             )->text( text = '{WIDTH} x {DEPTH} x {HEIGHT} {DIMUNIT}'
+             )->text( '{SUPPLIERNAME}' )->get_parent(
+             )->text( '{WIDTH} x {DEPTH} x {HEIGHT} {DIMUNIT}'
              )->object_number( number = '{MEASURE}'
                                unit   = '{UNIT}'
                                state  = '{STATE_MEASURE}'

--- a/src/z2ui5_cl_demo_app_090.clas.abap
+++ b/src/z2ui5_cl_demo_app_090.clas.abap
@@ -194,7 +194,7 @@ CLASS z2ui5_cl_demo_app_090 IMPLEMENTATION.
       ( n = `showReset`               v = `true` )
       ( n = `initialVisiblePanelType` v = `sort` )
       )
-      )->_generic( name = `panels`
+      )->_generic( `panels`
       )->_generic( name = `P13nColumnsPanel`
       t_prop            = VALUE #(
 *     ( n = `title`   v = `Columns` )
@@ -206,7 +206,7 @@ CLASS z2ui5_cl_demo_app_090 IMPLEMENTATION.
          )->_generic( name = `P13nItem`
            t_prop          = VALUE #( ( n = `columnKey` v = `{columnkey}` )
                              ( n = `text`      v = `{text}` ) ) )->get_parent( )->get_parent(
-      )->_generic( name = `columnsItems`
+      )->_generic( `columnsItems`
            )->_generic( name = `P13nColumnsItem`
                t_prop        = VALUE #( ( n = `columnKey` v = `{columnkey}` )
                                   ( n = `visible`   v = `{visible}` )
@@ -217,7 +217,7 @@ CLASS z2ui5_cl_demo_app_090 IMPLEMENTATION.
       )->_generic( name = `P13nItem`
            t_prop       = VALUE #( ( n = `columnKey` v = `{columnkey}` )
                              ( n = `text`      v = `{text}` ) ) )->get_parent( )->get_parent(
-      )->_generic( name = `groupItems`
+      )->_generic( `groupItems`
         )->_generic( name = `P13nGroupItem`
             t_prop        = VALUE #( ( n = `columnKey` v = `{columnkey}` )
                               ( n = `operation` v = `{operation}` )

--- a/src/z2ui5_cl_demo_app_091.clas.abap
+++ b/src/z2ui5_cl_demo_app_091.clas.abap
@@ -118,7 +118,7 @@ CLASS Z2UI5_CL_DEMO_APP_091 IMPLEMENTATION.
         nodepress     = client->_event( val = `NODE_PRESS` )
         nodes         = client->_bind_edit( mt_nodes )
         lanes         = client->_bind_edit( mt_lanes )
-      )->nodes( ns = `commons`
+      )->nodes( `commons`
         )->process_flow_node(
           laneid            = `{LANE}`
           nodeid            = `{ID}`

--- a/src/z2ui5_cl_demo_app_094.clas.abap
+++ b/src/z2ui5_cl_demo_app_094.clas.abap
@@ -77,12 +77,12 @@ CLASS Z2UI5_CL_DEMO_APP_094 IMPLEMENTATION.
     ASSIGN mr_screen->* TO <screen>.
 
     page = z2ui5_cl_xml_view=>factory( )->shell(
-          )->page( title = `test` ).
+          )->page( `test` ).
 
     DATA(o_grid) = page->grid( 'L6 M12 S12'
         )->content( 'layout' ).
 
-    DATA(content) = o_grid->simple_form( title = 'Input'
+    DATA(content) = o_grid->simple_form( 'Input'
           )->content( 'form' ).
 
     content->label( 'structure level 01'

--- a/src/z2ui5_cl_demo_app_095.clas.abap
+++ b/src/z2ui5_cl_demo_app_095.clas.abap
@@ -55,7 +55,7 @@ CLASS Z2UI5_CL_DEMO_APP_095 IMPLEMENTATION.
   METHOD on_event_sub.
 
     mo_app_sub->mo_view_parent = mo_grid_sub.
-    mo_app_sub->z2ui5_if_app~main( client = client ).
+    mo_app_sub->z2ui5_if_app~main( client ).
 
   ENDMETHOD.
 
@@ -72,7 +72,7 @@ CLASS Z2UI5_CL_DEMO_APP_095 IMPLEMENTATION.
 
     mo_app_sub = NEW #( ).
     mo_app_sub->mo_view_parent = mo_grid_sub.
-    mo_app_sub->z2ui5_if_app~main( client = client ).
+    mo_app_sub->z2ui5_if_app~main( client ).
 
     client->view_display( page->get_root( )->xml_get( ) ).
 
@@ -90,7 +90,7 @@ CLASS Z2UI5_CL_DEMO_APP_095 IMPLEMENTATION.
     DATA(o_grid) = page->grid( 'L6 M12 S12'
         )->content( 'layout' ).
 
-    DATA(content) = o_grid->simple_form( title = 'Input'
+    DATA(content) = o_grid->simple_form( 'Input'
           )->content( 'form' ).
     content->label( 'main app'
       )->input(

--- a/src/z2ui5_cl_demo_app_096.clas.abap
+++ b/src/z2ui5_cl_demo_app_096.clas.abap
@@ -53,7 +53,7 @@ CLASS Z2UI5_CL_DEMO_APP_096 IMPLEMENTATION.
     IF mo_view_parent IS NOT BOUND.
 
       DATA(page) = z2ui5_cl_xml_view=>factory( )->shell(
-         )->page( title = 'Main View' ).
+         )->page( 'Main View' ).
 
       mo_view_parent = page->grid( 'L6 M12 S12'
           )->content( 'layout' ).
@@ -66,7 +66,7 @@ CLASS Z2UI5_CL_DEMO_APP_096 IMPLEMENTATION.
 
     ENDIF.
 
-    mo_view_parent->input( value = client->_bind_edit( mv_descr ) ).
+    mo_view_parent->input( client->_bind_edit( mv_descr ) ).
     mo_view_parent->button( text  = `event sub app`
                             press = client->_event( `MESSAGE_SUB` ) ).
 

--- a/src/z2ui5_cl_demo_app_097.clas.abap
+++ b/src/z2ui5_cl_demo_app_097.clas.abap
@@ -44,7 +44,7 @@ CLASS Z2UI5_CL_DEMO_APP_097 IMPLEMENTATION.
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
 
-    DATA(page) = lo_view_nested->page( title = `Nested View` ).
+    DATA(page) = lo_view_nested->page( `Nested View` ).
 
     DATA(tab) = page->ui_table( rows               = client->_bind_edit( val = t_tab2 view = client->cs_view-nested )
                                 editable           = abap_false
@@ -56,15 +56,15 @@ CLASS Z2UI5_CL_DEMO_APP_097 IMPLEMENTATION.
                                 sort               = client->_event( 'SORT' )
                                 filter             = client->_event( 'FILTER' )
                                 customfilter       = client->_event( 'CUSTOMFILTER' ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( text = 'Products' ).
+    tab->ui_extension( )->overflow_toolbar( )->title( 'Products' ).
     DATA(lo_columns) = tab->ui_columns( ).
 
     lo_columns->ui_column( sortproperty                  = 'TITLE'
-                                          filterproperty = 'TITLE' )->text( text = `Index` )->ui_template( )->text( text = `{TITLE}` ).
+                                          filterproperty = 'TITLE' )->text( `Index` )->ui_template( )->text( `{TITLE}` ).
     lo_columns->ui_column( sortproperty   = 'DESCR'
-                           filterproperty = 'DESCR' )->text( text = `DESCR` )->ui_template( )->text( text = `{DESCR}` ).
+                           filterproperty = 'DESCR' )->text( `DESCR` )->ui_template( )->text( `{DESCR}` ).
     lo_columns->ui_column( sortproperty   = 'INFO'
-                           filterproperty = 'INFO' )->text( text = `INFO` )->ui_template( )->text( text = `{INFO}` ).
+                           filterproperty = 'INFO' )->text( `INFO` )->ui_template( )->text( `{INFO}` ).
     lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
        )->ui_row_action_item( icon = `sap-icon://delete`
                            press   = client->_event( val = 'ROW_DELETE' t_arg = VALUE #( ( `${TITLE}` ) ) ) ).

--- a/src/z2ui5_cl_demo_app_098.clas.abap
+++ b/src/z2ui5_cl_demo_app_098.clas.abap
@@ -48,7 +48,7 @@ CLASS Z2UI5_CL_DEMO_APP_098 IMPLEMENTATION.
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
 
-    DATA(page) = lo_view_nested->page( title = `Nested View` ).
+    DATA(page) = lo_view_nested->page( `Nested View` ).
 
     DATA(tab) = page->ui_table( rows               = client->_bind_edit( val = t_tab2 view = client->cs_view-nested )
                                 editable           = abap_false
@@ -60,15 +60,15 @@ CLASS Z2UI5_CL_DEMO_APP_098 IMPLEMENTATION.
                                 sort               = client->_event( 'SORT' )
                                 filter             = client->_event( 'FILTER' )
                                 customfilter       = client->_event( 'CUSTOMFILTER' ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( text = 'Products' ).
+    tab->ui_extension( )->overflow_toolbar( )->title( 'Products' ).
     DATA(lo_columns) = tab->ui_columns( ).
 
     lo_columns->ui_column( sortproperty                  = 'TITLE'
-                                          filterproperty = 'TITLE' )->text( text = `Index` )->ui_template( )->text( text = `{TITLE}` ).
+                                          filterproperty = 'TITLE' )->text( `Index` )->ui_template( )->text( `{TITLE}` ).
     lo_columns->ui_column( sortproperty   = 'DESCR'
-                           filterproperty = 'DESCR' )->text( text = `DESCR` )->ui_template( )->text( text = `{DESCR}` ).
+                           filterproperty = 'DESCR' )->text( `DESCR` )->ui_template( )->text( `{DESCR}` ).
     lo_columns->ui_column( sortproperty   = 'INFO'
-                           filterproperty = 'INFO')->text( text = `INFO` )->ui_template( )->text( text = `{INFO}` ).
+                           filterproperty = 'INFO')->text( `INFO` )->ui_template( )->text( `{INFO}` ).
     lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
        )->ui_row_action_item( type = `Navigation` "icon = `sap-icon://navigation-right-arrow`
                            press   = client->_event( val = 'ROW_NAVIGATE' t_arg = VALUE #( ( `${TITLE}` ) ) ) ).
@@ -86,9 +86,9 @@ CLASS Z2UI5_CL_DEMO_APP_098 IMPLEMENTATION.
 
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
 
-    DATA(page) = lo_view_nested->page( title = `Nested View` ).
+    DATA(page) = lo_view_nested->page( `Nested View` ).
 
-    page = page->text( text = client->_bind( mv_title )
+    page = page->text( client->_bind( mv_title )
        )->button(
            text  = `frontend event`
            press = client->_event_client( val = client->cs_event-open_new_tab t_arg = VALUE #( ( `https://github.com/abap2UI5/abap2UI5/` ) ) ) ).

--- a/src/z2ui5_cl_demo_app_099.clas.abap
+++ b/src/z2ui5_cl_demo_app_099.clas.abap
@@ -237,17 +237,17 @@ CLASS Z2UI5_CL_DEMO_APP_099 IMPLEMENTATION.
                      press   = client->_event( `ALL` )
          )->get_parent( )->get_parent(
        )->columns(
-        )->column( )->text( text = `Title` )->get_parent(
-        )->column( )->text( text = `Info` )->get_parent(
-        )->column( )->text( text = `Descr` )->get_parent(
-        )->column( )->text( text = `Icon` )->get_parent(
+        )->column( )->text( `Title` )->get_parent(
+        )->column( )->text( `Info` )->get_parent(
+        )->column( )->text( `Descr` )->get_parent(
+        )->column( )->text( `Icon` )->get_parent(
        )->get_parent(
       )->items(
         )->column_list_item( valign = `Middle`
           )->cells(
-            )->text( text = `{TITLE}`
-            )->text( text = `{INFO}`
-            )->text( text = `{DESCR}`
+            )->text( `{TITLE}`
+            )->text( `{INFO}`
+            )->text( `{DESCR}`
             )->avatar( src = `{ICON}` ).
 
     client->view_display( view->stringify( ) ).

--- a/src/z2ui5_cl_demo_app_100.clas.abap
+++ b/src/z2ui5_cl_demo_app_100.clas.abap
@@ -104,22 +104,22 @@ CLASS Z2UI5_CL_DEMO_APP_100 IMPLEMENTATION.
                                     sort               = client->_event( 'SORT' )
                                     filter             = client->_event( 'FILTER' )
                                     customfilter       = client->_event( 'CUSTOMFILTER' ) ).
-    tab->ui_extension( )->overflow_toolbar( )->title( text = 'Products' )->toolbar_spacer(
+    tab->ui_extension( )->overflow_toolbar( )->title( 'Products' )->toolbar_spacer(
       )->variant_management( showexecuteonselection = abap_true
         )->variant_items(
           )->variant_item( key                = `{KEY}`
                            text               = `{TEXT}`
                            executeonselection = abap_true )->get_parent( ).
     DATA(lo_columns) = tab->ui_columns( ).
-    lo_columns->ui_column( width = '4rem' )->checkbox( selected = client->_bind_edit( lv_selkz )
+    lo_columns->ui_column( '4rem' )->checkbox( selected = client->_bind_edit( lv_selkz )
                                                        enabled  = abap_true
-                                                       select   = client->_event( `SELKZ` ) )->ui_template( )->checkbox( selected = `{SELKZ}` ).
+                                                       select   = client->_event( `SELKZ` ) )->ui_template( )->checkbox( `{SELKZ}` ).
     lo_columns->ui_column( width                         = '5rem'
                            sortproperty                  = 'ROW_ID'
-                                          filterproperty = 'ROW_ID' )->text( text = `Index` )->ui_template( )->text( text = `{ROW_ID}` ).
+                                          filterproperty = 'ROW_ID' )->text( `Index` )->ui_template( )->text( `{ROW_ID}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PROCESS'
-                           filterproperty = 'PROCESS' )->text( text = `Process Indicator`
+                           filterproperty = 'PROCESS' )->text( `Process Indicator`
       )->ui_template( )->progress_indicator( class        = 'sapUiSmallMarginBottom'
                                              percentvalue = `{PROCESS}`
                                              displayvalue = '{PROCESS} %'
@@ -127,26 +127,26 @@ CLASS Z2UI5_CL_DEMO_APP_100 IMPLEMENTATION.
                                              state        = '{PROCESS_STATE}' ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PRODUCT'
-                           filterproperty = 'PRODUCT' )->text( text = `Product` )->ui_template( )->input( value    = `{PRODUCT}`
+                           filterproperty = 'PRODUCT' )->text( `Product` )->ui_template( )->input( value    = `{PRODUCT}`
                                                                                                           editable = abap_false ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'CREATE_DATE'
-                           filterproperty = 'CREATE_DATE' )->text( text = `Date` )->ui_template( )->text( text = `{CREATE_DATE}` ).
+                           filterproperty = 'CREATE_DATE' )->text( `Date` )->ui_template( )->text( `{CREATE_DATE}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'CREATE_BY'
-                           filterproperty = 'CREATE_BY' )->text( text = `Name` )->ui_template( )->text( text = `{CREATE_BY}` ).
+                           filterproperty = 'CREATE_BY' )->text( `Name` )->ui_template( )->text( `{CREATE_BY}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'STORAGE_LOCATION'
-                           filterproperty = 'STORAGE_LOCATION' )->text( text = `Location` )->ui_template( )->text( text = `{STORAGE_LOCATION}` ).
+                           filterproperty = 'STORAGE_LOCATION' )->text( `Location` )->ui_template( )->text( `{STORAGE_LOCATION}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'QUANTITY'
-                           filterproperty = 'QUANTITY' )->text( text = `Quantity` )->ui_template( )->text( text = `{QUANTITY}` ).
+                           filterproperty = 'QUANTITY' )->text( `Quantity` )->ui_template( )->text( `{QUANTITY}` ).
     lo_columns->ui_column( width          = '6rem'
                            sortproperty   = 'MEINS'
-                           filterproperty = 'MEINS' )->text( text = `Unit` )->ui_template( )->text( text = `{MEINS}` ).
+                           filterproperty = 'MEINS' )->text( `Unit` )->ui_template( )->text( `{MEINS}` ).
     lo_columns->ui_column( width          = '11rem'
                            sortproperty   = 'PRICE'
-                           filterproperty = 'PRICE' )->text( text = `Price` )->ui_template( )->currency( value    = `{PRICE}`
+                           filterproperty = 'PRICE' )->text( `Price` )->ui_template( )->currency( value    = `{PRICE}`
                                                                                                          currency = `{WAERS}` ).
     lo_columns->get_parent( )->ui_row_action_template( )->ui_row_action(
       )->ui_row_action_item( type = 'Navigation'

--- a/src/z2ui5_cl_demo_app_103.clas.abap
+++ b/src/z2ui5_cl_demo_app_103.clas.abap
@@ -54,16 +54,16 @@ CLASS z2ui5_cl_demo_app_103 IMPLEMENTATION.
        )->pane_container(
          )->split_pane( requiredparentwidth = `400`
                         id                  = `default`
-           )->layout_data( ns = `layout`
+           )->layout_data( `layout`
              )->splitter_layout_data( size = `auto` )->get_parent( )->get_parent(
            )->panel( headertext = `first pane` )->get_parent( )->get_parent(
          )->pane_container( orientation = `Vertical`
            )->split_pane( requiredparentwidth = `600`
-             )->layout_data( ns = `layout`
+             )->layout_data( `layout`
                )->splitter_layout_data( size = `auto` )->get_parent( )->get_parent(
              )->panel( headertext = `second pane` )->get_parent( )->get_parent(
            )->split_pane( requiredparentwidth = `800`
-             )->layout_data( ns = `layout`
+             )->layout_data( `layout`
                )->splitter_layout_data( size = `auto` )->get_parent( )->get_parent(
              )->panel( headertext = `second pane` ).
 

--- a/src/z2ui5_cl_demo_app_104.clas.abap
+++ b/src/z2ui5_cl_demo_app_104.clas.abap
@@ -78,7 +78,7 @@ CLASS z2ui5_cl_demo_app_104 IMPLEMENTATION.
   METHOD view_display_detail.
 
     lo_view_nested = z2ui5_cl_xml_view=>factory( ).
-    DATA(page) = lo_view_nested->page( title = `Nested View` ).
+    DATA(page) = lo_view_nested->page( `Nested View` ).
     mo_grid_sub = page->grid( 'L12 M12 S12'
         )->content( 'layout' ).
 

--- a/src/z2ui5_cl_demo_app_107.clas.abap
+++ b/src/z2ui5_cl_demo_app_107.clas.abap
@@ -120,7 +120,7 @@ CLASS Z2UI5_CL_DEMO_APP_107 IMPLEMENTATION.
                                   )->toolbar_spacer(
                                   )->upload_set_toolbar_placeholder(
                               )->get_parent( )->get_parent( )->get_parent(
-                              )->items( ns = `upload`
+                              )->items( `upload`
                                 )->upload_set_item( filename  = `{FILENAME}`
                                                     url       = `{URL}`
                                                     mediatype = `{MEDIATYPE}`

--- a/src/z2ui5_cl_demo_app_108.clas.abap
+++ b/src/z2ui5_cl_demo_app_108.clas.abap
@@ -79,16 +79,16 @@ CLASS Z2UI5_CL_DEMO_APP_108 IMPLEMENTATION.
         )->button( text = `Button 1`
         )->button( text = `Button 2`
         )->vbox(
-          )->label( text = `Switch 1`
+          )->label( `Switch 1`
           )->switch(
           )->get_parent(
-        )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut` &&
+        )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut` &&
                         `labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris` &&
                         `nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse` &&
                         `cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui` &&
                         `officia deserunt mollit anim id est laborum`
                         )->get_parent(
-          )->items( ns = `f`
+          )->items( `f`
             )->side_panel_item( icon = `sap-icon://physical-activity`
                                 text = `Run`
               )->vbox(

--- a/src/z2ui5_cl_demo_app_109.clas.abap
+++ b/src/z2ui5_cl_demo_app_109.clas.abap
@@ -84,7 +84,7 @@ CLASS z2ui5_cl_demo_app_109 IMPLEMENTATION.
               )->content( 'form'
                   )->title( 'QuickView Popover'
                   )->label( 'placement'
-                  )->segmented_button( selected_key = client->_bind_edit( mv_placement )
+                  )->segmented_button( client->_bind_edit( mv_placement )
                         )->items(
                         )->segmented_button_item(
                                 key  = 'Left'

--- a/src/z2ui5_cl_demo_app_110.clas.abap
+++ b/src/z2ui5_cl_demo_app_110.clas.abap
@@ -39,7 +39,7 @@ CLASS Z2UI5_CL_DEMO_APP_110 IMPLEMENTATION.
                           layout   = 'ColumnLayout'
                           editable = abap_true
 *              )->content( 'form'
-                  )->label( text = 'Unique ID'
+                  )->label( 'Unique ID'
                   )->mask_input( mask              = `~~~~~~~~~~`
                                  placeholdersymbol = `_`
                                  placeholder       = 'All characters allowed' )->get(
@@ -47,14 +47,14 @@ CLASS Z2UI5_CL_DEMO_APP_110 IMPLEMENTATION.
                       )->mask_input_rule( maskformatsymbol = '~'
                                           regex            = `[^_]`
                     )->get_parent( )->get_parent( )->get_parent(
-                 )->label( text = `Promo code`
+                 )->label( `Promo code`
                  )->mask_input( mask              = `**********`
                                 placeholdersymbol = `_`
                                 placeholder       = `Latin characters (case insensitive) and numbers` )->get(
                   )->rules(
                     )->mask_input_rule(
                   )->get_parent( )->get_parent( )->get_parent(
-                )->label( text = `Phone number`
+                )->label( `Phone number`
                  )->mask_input( mask              = `(999) 999 999999`
                                 placeholdersymbol = `_`
                                 placeholder       = `Enter twelve-digit number`
@@ -65,7 +65,7 @@ CLASS Z2UI5_CL_DEMO_APP_110 IMPLEMENTATION.
       )->simple_form( title    = 'Possible usages (may require additional coding)'
                       layout   = 'ColumnLayout'
                       editable = abap_true
-                )->label( text = `Serial number`
+                )->label( `Serial number`
                  )->mask_input( mask              = `CCCC-CCCC-CCCC-CCCC-CCCC`
                                 placeholdersymbol = `_`
                                 placeholder       = `Enter digits and capital letters`
@@ -74,7 +74,7 @@ CLASS Z2UI5_CL_DEMO_APP_110 IMPLEMENTATION.
                     )->mask_input_rule( maskformatsymbol = `C`
                                         regex            = `[A-Z0-9]`
                   )->get_parent( )->get_parent( )->get_parent(
-                )->label( text = `Product activation key`
+                )->label( `Product activation key`
                  )->mask_input( mask              = `SAP-CCCCC-CCCCC`
                                 placeholdersymbol = `_`
                                 placeholder       = `Starts with 'SAP' followed by digits and capital letters`
@@ -83,7 +83,7 @@ CLASS Z2UI5_CL_DEMO_APP_110 IMPLEMENTATION.
                     )->mask_input_rule( maskformatsymbol = `C`
                                         regex            = `[A-Z0-9]`
                   )->get_parent( )->get_parent( )->get_parent(
-                )->label( text = `ISBN`
+                )->label( `ISBN`
                  )->mask_input( mask              = `999-99-999-9999-9`
                                 placeholdersymbol = `_`
                                 placeholder       = `Enter thirteen-digit number`

--- a/src/z2ui5_cl_demo_app_111.clas.abap
+++ b/src/z2ui5_cl_demo_app_111.clas.abap
@@ -138,12 +138,12 @@ CLASS z2ui5_cl_demo_app_111 IMPLEMENTATION.
                                       headerpinned   = abap_true ).
 
     DATA(header_title) = page->title( ns = 'f' )->get( )->dynamic_page_title( ).
-    header_title->heading( ns = 'f' )->smart_variant_management( id                     = `svm`
+    header_title->heading( 'f' )->smart_variant_management( id                     = `svm`
                                                                  showexecuteonselection = abap_true ).
     header_title->expanded_content( 'f' ).
-    header_title->snapped_content( ns = 'f' ).
+    header_title->snapped_content( 'f' ).
 
-    DATA(lo_fb) = page->header( )->dynamic_page_header( pinnable = abap_true ).
+    DATA(lo_fb) = page->header( )->dynamic_page_header( abap_true ).
 
     lo_fb->filter_bar( id             = `fbar`
                        persistencykey = `myPersKey`
@@ -194,17 +194,17 @@ CLASS z2ui5_cl_demo_app_111 IMPLEMENTATION.
               )->get( )->suggestion_items( )->item( text = `{QUANTITY}`
             )->get_parent( )->get_parent( )->get_parent( ).
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
 
     DATA(tab) = cont->table( id    = `table1`
                              items = client->_bind_edit( val = mt_table ) ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_113.clas.abap
+++ b/src/z2ui5_cl_demo_app_113.clas.abap
@@ -92,7 +92,7 @@ CLASS z2ui5_cl_demo_app_113 IMPLEMENTATION.
     DATA(timeline) = page->timeline(
           content = client->_bind( mt_feed ) ).
 
-    timeline->content( ns = `commons` )->timeline_item(
+    timeline->content( `commons` )->timeline_item(
         datetime    = `{DATETIME}`
         title       = `{TITLE}`
         userpicture = `{AUTHORPIC}`

--- a/src/z2ui5_cl_demo_app_116.clas.abap
+++ b/src/z2ui5_cl_demo_app_116.clas.abap
@@ -120,9 +120,9 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
     DATA(header_title) = page->header_title( )->object_page_dyn_header_title( ).
     header_title->expanded_heading(
             )->hbox(
-                )->title( text = 'PriceList' ).
+                )->title( 'PriceList' ).
 
-    DATA(header_content) = page->header_content( ns = 'uxap').
+    DATA(header_content) = page->header_content( 'uxap').
     header_content->block_layout(
       )->block_layout_row(
       )->block_layout_cell( backgroundcolorset   = 'ColorSet10'
@@ -134,7 +134,7 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
                     text   = 'Something:'
       )->get_parent(
       )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
-        )->text( text = 'Other'
+        )->text( 'Other'
       )->get_parent( )->get_parent(
       )->hbox( justifycontent = 'End'
         )->vertical_layout( class = 'sapUiSmallMarginBeginEnd'
@@ -155,7 +155,7 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
     DATA(cont) = sections->object_page_section( titleuppercase = abap_false
                                                 id             = 'Sets'
                                                 title          = 'Sets'
-        )->heading( ns = `uxap`
+        )->heading( `uxap`
         )->get_parent(
         )->sub_sections(
             )->object_page_sub_section( id    = 'SETS'
@@ -166,20 +166,20 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
                          rows            = `{path:'` && client->_bind( val = prodh_nodes path = abap_true ) && `', parameters: {arrayNames:['NODES']}}`
                          toggleopenstate = `saveState()`
                          )->tree_columns(
-                          )->tree_column( label = 'Label'
+                          )->tree_column( 'Label'
                           )->tree_template(
-                           )->text( text = `{TEXT}`
+                           )->text( `{TEXT}`
                           )->get_parent( )->get_parent(
-                          )->tree_column( label = 'PRODH'
+                          )->tree_column( 'PRODH'
                           )->tree_template(
-                           )->text( text = `{PRODH}`
+                           )->text( `{PRODH}`
                           )->get_parent( )->get_parent(
-                          )->tree_column( label = 'Counter'
+                          )->tree_column( 'Counter'
                           )->tree_template(
                            )->link( text    = `{COUNTER}`
                                       press = client->_event( val = 'POPOVER' t_arg = VALUE #( ( `${$source>/id}` ) ) )
       )->get_parent( )->get_parent(
-                          )->tree_column( label = 'ADD'
+                          )->tree_column( 'ADD'
                           )->tree_template(
                            )->button( icon = 'sap-icon://add'
                                  press     = client->_event( val = 'ROW_ADD' t_arg = VALUE #( ( `${PRODH}` ) ) )
@@ -275,7 +275,7 @@ CLASS Z2UI5_CL_DEMO_APP_116 IMPLEMENTATION.
 
         client->view_model_update( ).
 
-        client->follow_up_action( val = `setState();` ).
+        client->follow_up_action( `setState();` ).
 
     ENDCASE.
 

--- a/src/z2ui5_cl_demo_app_123.clas.abap
+++ b/src/z2ui5_cl_demo_app_123.clas.abap
@@ -75,11 +75,11 @@ CLASS z2ui5_cl_demo_app_123 IMPLEMENTATION.
                     shownavbutton  = client->check_app_prev_stack( ) ).
 
     DATA(map) = page->map_container( autoadjustheight = abap_true
-         )->content( ns = `vk`
+         )->content( `vk`
              )->container_content(
                title = `Analytic Map`
                icon  = `sap-icon://geographic-bubble-chart`
-                 )->content( ns = `vk`
+                 )->content( `vk`
                      )->analytic_map(
                        initialposition = `9.933573;50;0`
                        initialzoom     = `6` ).

--- a/src/z2ui5_cl_demo_app_129.clas.abap
+++ b/src/z2ui5_cl_demo_app_129.clas.abap
@@ -136,7 +136,7 @@ CLASS Z2UI5_CL_DEMO_APP_129 IMPLEMENTATION.
     DATA(grid) = page->grid( 'L6 M12 S12'
         )->content( 'layout' ).
 
-    grid = grid->text( text = client->_bind_edit( val = lv_text view = client->cs_view-main
+    grid = grid->text( client->_bind_edit( val = lv_text view = client->cs_view-main
       ) ).
 
     page->footer( )->overflow_toolbar(
@@ -159,7 +159,7 @@ CLASS Z2UI5_CL_DEMO_APP_129 IMPLEMENTATION.
   METHOD z2ui5_on_rendering_popover.
     DATA(popover) = z2ui5_cl_xml_view=>factory_popup( )->popover( placement = `Top` ).
 
-    popover->text( text = 'this is popover in middle with timer auto refresh' ).
+    popover->text( 'this is popover in middle with timer auto refresh' ).
     client->popover_display( xml   = popover->stringify( )
                              by_id = id ).
   ENDMETHOD.
@@ -169,7 +169,7 @@ CLASS Z2UI5_CL_DEMO_APP_129 IMPLEMENTATION.
 
     DATA(dialog) = z2ui5_cl_xml_view=>factory_popup( )->dialog( ).
 
-    dialog->text( text = 'this is popup in middle with timer auto refresh' ).
+    dialog->text( 'this is popup in middle with timer auto refresh' ).
     dialog->button( text  = 'close'
                     press = client->_event_client( client->cs_event-popup_close ) ).
     client->popup_display( dialog->stringify( ) ).

--- a/src/z2ui5_cl_demo_app_130.clas.abap
+++ b/src/z2ui5_cl_demo_app_130.clas.abap
@@ -358,7 +358,7 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
 
     grid->simple_form( get_txt( 'BU_DYNID' )
         )->content( 'form'
-            )->label( text = get_txt( 'BU_DYNID' )
+            )->label( get_txt( 'BU_DYNID' )
              )->combobox(
              change      = client->_event( 'INPUT_SCREEN_CHANGE' )
              items       = client->_bind_edit( mt_screens )
@@ -366,7 +366,7 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
                  )->item(
                      key  = '{SCREEN_NAME}'
                      text = '{SCREEN_NAME} - {DESCR}'
-         )->get_parent( )->label( text = get_txt( 'DESCR_40' )
+         )->get_parent( )->label( get_txt( 'DESCR_40' )
             )->input(
             value         = client->_bind_edit( mv_screen_descr )
             showvaluehelp = abap_false
@@ -376,13 +376,13 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
 
     grid->simple_form( get_txt( '/SCWM/WB_VARIANT' )
             )->content( 'form'
-                )->label( text = get_txt( '/SCWM/WB_VARIANT' )
+                )->label( get_txt( '/SCWM/WB_VARIANT' )
             )->input(
             value            = client->_bind_edit( mv_variant )
             showvaluehelp    = abap_true
             valuehelprequest = client->_event( 'CALL_POPUP_VARIANT' )
             submit           = client->_event( 'INPUT_VARIANT_CHANGE' )
-            )->label( text = get_txt( 'DESCR_40' )
+            )->label( get_txt( 'DESCR_40' )
             )->input(
             value         = client->_bind_edit( mv_description )
             showvaluehelp = abap_false ).
@@ -397,7 +397,7 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
 
         DATA(scrtext) = get_txt( CONV #( lr_tab->field_doma ) ).
 
-        content->label( text = scrtext
+        content->label( scrtext
           )->multi_input(
                    tokens           = client->_bind( val = lr_tab->t_token tab = mt_fields tab_index = lv_tabix )
                    showclearicon    = abap_true
@@ -473,7 +473,7 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
                      key  = '{N}'
                      text = '{N}'
              )->get_parent(
-             )->input( value = `{LOW}`
+             )->input( `{LOW}`
              )->input( value   = `{HIGH}`
                        visible = `{= ${OPTION} === 'BT' }`
              )->button( icon = 'sap-icon://decline'
@@ -544,11 +544,11 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
 
     lo_popup->simple_form( get_txt( '/SCWM/WB_VARIANT' )
                )->content( 'form'
-                   )->label( text = get_txt( '/SCWM/WB_VARIANT' )
+                   )->label( get_txt( '/SCWM/WB_VARIANT' )
                )->input(
                value         = client->_bind_edit( mv_variant_copy )
                showvaluehelp = abap_false
-               )->label( text = get_txt( 'DESCR_40' )
+               )->label( get_txt( 'DESCR_40' )
                )->input(
                value         = client->_bind_edit( mv_description_copy )
                showvaluehelp = abap_false ).

--- a/src/z2ui5_cl_demo_app_136.clas.abap
+++ b/src/z2ui5_cl_demo_app_136.clas.abap
@@ -85,7 +85,7 @@ CLASS z2ui5_cl_demo_app_136 IMPLEMENTATION.
       ASSIGN mr_table->* TO <tab>.
 
       DATA(tab) = page->table(
-              items = COND #( WHEN mv_check_edit = abap_true THEN client->_bind_edit( <tab> ) ELSE client->_bind_edit( <tab> ) )
+              COND #( WHEN mv_check_edit = abap_true THEN client->_bind_edit( <tab> ) ELSE client->_bind_edit( <tab> ) )
           )->header_toolbar(
               )->overflow_toolbar(
                   )->title( 'CSV Content'

--- a/src/z2ui5_cl_demo_app_143.clas.abap
+++ b/src/z2ui5_cl_demo_app_143.clas.abap
@@ -63,14 +63,14 @@ CLASS z2ui5_cl_demo_app_143 IMPLEMENTATION.
 
     DATA(page) = page1->dynamic_page( headerexpanded = abap_true
                                       headerpinned   = abap_true ).
-    page1->_z2ui5( )->uitableext( tableid = `Table1` ).
+    page1->_z2ui5( )->uitableext( `Table1` ).
 
     DATA(header_title) = page->title( ns = 'f' )->get( )->dynamic_page_title( ).
-    header_title->heading( ns = 'f' )->hbox( )->title( `Table` ).
+    header_title->heading( 'f' )->hbox( )->title( `Table` ).
     header_title->expanded_content( 'f' ).
-    header_title->snapped_content( ns = 'f' ).
+    header_title->snapped_content( 'f' ).
 
-    DATA(cont) = page->content( ns = 'f' ).
+    DATA(cont) = page->content( 'f' ).
 
 
     DATA(tab) = cont->vbox(
@@ -88,20 +88,20 @@ CLASS z2ui5_cl_demo_app_143 IMPLEMENTATION.
                               )->ui_column( sortproperty   = 'FIELD1'
                                             filterproperty = 'FIELD1'
                                             autoresizable  = 'true'
-                                             )->text( text = `Field1`
-                                              )->ui_template( )->text( text = `{FIELD1}`
+                                             )->text( `Field1`
+                                              )->ui_template( )->text( `{FIELD1}`
                                )->get_parent( )->get_parent(
                                )->ui_column( sortproperty   = 'FIELD2'
                                              filterproperty = 'FIELD2'
                                              autoresizable  = 'true'
-                                              )->text( text = `Field2`
-                                               )->ui_template( )->text( text = `{FIELD2}`
+                                              )->text( `Field2`
+                                               )->ui_template( )->text( `{FIELD2}`
                                )->get_parent( )->get_parent(
                                )->ui_column( sortproperty   = 'FIELD3'
                                              filterproperty = 'FIELD3'
                                              autoresizable  = 'true'
-                                              )->text( text = `Field3`
-                                               )->ui_template( )->text( text = `{FIELD3}`
+                                              )->text( `Field3`
+                                               )->ui_template( )->text( `{FIELD3}`
                          )->get_parent( )->get_parent( )->get_parent(
                               )->ui_row_action_template( )->ui_row_action(
                               )->ui_row_action_item( icon = 'sap-icon://add'

--- a/src/z2ui5_cl_demo_app_144.clas.abap
+++ b/src/z2ui5_cl_demo_app_144.clas.abap
@@ -38,8 +38,8 @@ CLASS z2ui5_cl_demo_app_144 IMPLEMENTATION.
 
     LOOP AT t_tab REFERENCE INTO DATA(lr_row).
       DATA(lv_tabix) = sy-tabix.
-      page->input( value = client->_bind_edit( val = lr_row->title tab = t_tab tab_index = lv_tabix ) ).
-      page->input( value = client->_bind_edit( val = lr_row->value tab = t_tab tab_index = lv_tabix ) ).
+      page->input( client->_bind_edit( val = lr_row->title tab = t_tab tab_index = lv_tabix ) ).
+      page->input( client->_bind_edit( val = lr_row->value tab = t_tab tab_index = lv_tabix ) ).
     ENDLOOP.
 
     DATA(tab) = page->table(
@@ -54,13 +54,13 @@ CLASS z2ui5_cl_demo_app_144 IMPLEMENTATION.
         )->column( )->text( 'Value' )->get_parent( )->get_parent(
       )->items( )->column_list_item( selected = '{SELKZ}'
       )->cells(
-          )->input( value = '{TITLE}'
-          )->input( value = '{VALUE}' ).
+          )->input( '{TITLE}'
+          )->input( '{VALUE}' ).
 
-    page->input( value = client->_bind_edit( val = t_tab[ 1 ]-title tab = t_tab tab_index = 1 ) ).
-    page->input( value = client->_bind_edit( val = t_tab[ 1 ]-value tab = t_tab tab_index = 1 ) ).
-    page->input( value = client->_bind_edit( val = t_tab[ 2 ]-title tab = t_tab tab_index = 2 ) ).
-    page->input( value = client->_bind_edit( val = t_tab[ 2 ]-value tab = t_tab tab_index = 2 ) ).
+    page->input( client->_bind_edit( val = t_tab[ 1 ]-title tab = t_tab tab_index = 1 ) ).
+    page->input( client->_bind_edit( val = t_tab[ 1 ]-value tab = t_tab tab_index = 1 ) ).
+    page->input( client->_bind_edit( val = t_tab[ 2 ]-title tab = t_tab tab_index = 2 ) ).
+    page->input( client->_bind_edit( val = t_tab[ 2 ]-value tab = t_tab tab_index = 2 ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_160.clas.abap
+++ b/src/z2ui5_cl_demo_app_160.clas.abap
@@ -123,20 +123,20 @@ CLASS z2ui5_cl_demo_app_160 IMPLEMENTATION.
 
     columns->ui_column( width          = '5.2rem'
                         sortproperty   = 'SET_SK'
-                        filterproperty = 'SET_SK' )->text( text = 'Column 1' )->ui_template( )->text( text = `{SET_SK}` ).
+                        filterproperty = 'SET_SK' )->text( 'Column 1' )->ui_template( )->text( `{SET_SK}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'MATNR'
-                        filterproperty = 'MATNR' )->text( text = 'Column 2' )->ui_template( )->text( text = `{MATNR}` ).
+                        filterproperty = 'MATNR' )->text( 'Column 2' )->ui_template( )->text( `{MATNR}` ).
     columns->ui_column( width          = '20rem'
                         sortproperty   = 'DESCRIPTION'
-                        filterproperty = 'DESCRIPTION' )->text( text = 'Column 3' )->ui_template( )->text( text = `{DESCRIPTION}` ).
+                        filterproperty = 'DESCRIPTION' )->text( 'Column 3' )->ui_template( )->text( `{DESCRIPTION}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_TOTAL'
-                        filterproperty = 'IS_TOTAL' )->text( text = 'Column 4' )->ui_template( )->text( text = `{IS_TOTAL}` ).
+                        filterproperty = 'IS_TOTAL' )->text( 'Column 4' )->ui_template( )->text( `{IS_TOTAL}` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_TOTAL'
-                        filterproperty = 'PL_TOTAL' )->text( text = 'Column 5' )->ui_template( )->input(
+                        filterproperty = 'PL_TOTAL' )->text( 'Column 5' )->ui_template( )->input(
       value           = `{PL_TOTAL}`
       submit          = client->_event( val = 'PL_TOTAL_CHANGE' t_arg = VALUE #(
         ( `${$source>/id}` )
@@ -148,89 +148,89 @@ CLASS z2ui5_cl_demo_app_160 IMPLEMENTATION.
 
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_total'
-                        filterproperty = 'per_cent_total' )->text( text = 'Column 6' )->ui_template( )->text( text = `{per_cent_total} %` ).
+                        filterproperty = 'per_cent_total' )->text( 'Column 6' )->ui_template( )->text( `{per_cent_total} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_01_PREV'
-                        filterproperty = 'IS_01_PREV' )->text( text = 'Column 7' )->ui_template( )->text( text = `{IS_01_PREV}` ).
+                        filterproperty = 'IS_01_PREV' )->text( 'Column 7' )->ui_template( )->text( `{IS_01_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_01'
-                        filterproperty = 'PL_01' )->text( text = 'Column 8' )->ui_template( )->input( value    = `{PL_01}`
+                        filterproperty = 'PL_01' )->text( 'Column 8' )->ui_template( )->input( value    = `{PL_01}`
                                                                                                       editable = abap_true
                                                                                                       type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_01'
-                        filterproperty = 'per_cent_01' )->text( text = 'Column 9' )->ui_template( )->text( text = `{per_cent_01} %` ).
+                        filterproperty = 'per_cent_01' )->text( 'Column 9' )->ui_template( )->text( `{per_cent_01} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_02_PREV'
-                        filterproperty = 'IS_02_PREV' )->text( text = 'Column 10' )->ui_template( )->text( text = `{IS_02_PREV}` ).
+                        filterproperty = 'IS_02_PREV' )->text( 'Column 10' )->ui_template( )->text( `{IS_02_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_02'
-                        filterproperty = 'PL_02' )->text( text = 'Column 11' )->ui_template( )->input( value    = `{PL_02}`
+                        filterproperty = 'PL_02' )->text( 'Column 11' )->ui_template( )->input( value    = `{PL_02}`
                                                                                                        editable = abap_true
                                                                                                        type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_02'
-                        filterproperty = 'per_cent_02' )->text( text = 'Column 12' )->ui_template( )->text( text = `{per_cent_02} %` ).
+                        filterproperty = 'per_cent_02' )->text( 'Column 12' )->ui_template( )->text( `{per_cent_02} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_03_PREV'
-                        filterproperty = 'IS_03_PREV' )->text( text = 'Column 13' )->ui_template( )->text( text = `{IS_03_PREV}` ).
+                        filterproperty = 'IS_03_PREV' )->text( 'Column 13' )->ui_template( )->text( `{IS_03_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_03'
-                        filterproperty = 'PL_03' )->text( text = 'Column 14' )->ui_template( )->input( value    = `{PL_03}`
+                        filterproperty = 'PL_03' )->text( 'Column 14' )->ui_template( )->input( value    = `{PL_03}`
                                                                                                        editable = abap_true
                                                                                                        type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_03'
-                        filterproperty = 'per_cent_03' )->text( text = 'Column 15' )->ui_template( )->text( text = `{per_cent_03} %` ).
+                        filterproperty = 'per_cent_03' )->text( 'Column 15' )->ui_template( )->text( `{per_cent_03} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_Q01_PREV'
-                        filterproperty = 'IS_Q01_PREV' )->text( text = 'Column 16' )->ui_template( )->text( text = `{IS_Q01_PREV}` ).
+                        filterproperty = 'IS_Q01_PREV' )->text( 'Column 16' )->ui_template( )->text( `{IS_Q01_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_Q01'
-                        filterproperty = 'PL_Q01' )->text( text = 'Column 17' )->ui_template( )->text( text = `{PL_Q01}` ). "Nicht editierbar, da im Detail geplant
+                        filterproperty = 'PL_Q01' )->text( 'Column 17' )->ui_template( )->text( `{PL_Q01}` ). "Nicht editierbar, da im Detail geplant
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_q01'
-                        filterproperty = 'per_cent_q01' )->text( text = 'Column 18' )->ui_template( )->text( text = `{per_cent_q01} %` ).
+                        filterproperty = 'per_cent_q01' )->text( 'Column 18' )->ui_template( )->text( `{per_cent_q01} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_Q02_PREV'
-                        filterproperty = 'IS_Q02_PREV' )->text( text = 'Column 19' )->ui_template( )->text( text = `{IS_Q02_PREV}` ).
+                        filterproperty = 'IS_Q02_PREV' )->text( 'Column 19' )->ui_template( )->text( `{IS_Q02_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_Q02'
-                        filterproperty = 'PL_Q02' )->text( text = 'Column 20' )->ui_template( )->input( value    = `{PL_Q02}`
+                        filterproperty = 'PL_Q02' )->text( 'Column 20' )->ui_template( )->input( value    = `{PL_Q02}`
                                                                                                         editable = abap_true
                                                                                                         type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_q02'
-                        filterproperty = 'per_cent_q02' )->text( text = 'Column 21' )->ui_template( )->text( text = `{per_cent_q02} %` ).
+                        filterproperty = 'per_cent_q02' )->text( 'Column 21' )->ui_template( )->text( `{per_cent_q02} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_Q03_PREV'
-                        filterproperty = 'IS_Q03_PREV' )->text( text = 'Column 22' )->ui_template( )->text( text = `{IS_Q03_PREV}` ).
+                        filterproperty = 'IS_Q03_PREV' )->text( 'Column 22' )->ui_template( )->text( `{IS_Q03_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_Q03'
-                        filterproperty = 'PL_Q03' )->text( text = 'Column 23' )->ui_template( )->input( value    = `{PL_Q03}`
+                        filterproperty = 'PL_Q03' )->text( 'Column 23' )->ui_template( )->input( value    = `{PL_Q03}`
                                                                                                         editable = abap_true
                                                                                                         type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_q03'
-                        filterproperty = 'per_cent_q03' )->text( text = 'Column 24' )->ui_template( )->text( text = `{per_cent_q03} %` ).
+                        filterproperty = 'per_cent_q03' )->text( 'Column 24' )->ui_template( )->text( `{per_cent_q03} %` ).
 
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'IS_Q04_PREV'
-                        filterproperty = 'IS_Q04_PREV' )->text( text = 'Column 25' )->ui_template( )->text( text = `{IS_Q04_PREV}` ).
+                        filterproperty = 'IS_Q04_PREV' )->text( 'Column 25' )->ui_template( )->text( `{IS_Q04_PREV}` ).
     columns->ui_column( width          = '5rem'
                         sortproperty   = 'PL_Q04'
-                        filterproperty = 'PL_Q04' )->text( text = 'Column 26' )->ui_template( )->input( value    = `{PL_Q04}`
+                        filterproperty = 'PL_Q04' )->text( 'Column 26' )->ui_template( )->input( value    = `{PL_Q04}`
                                                                                                         editable = abap_true
                                                                                                         type     = 'Number' ).
     columns->ui_column( width          = '4rem'
                         sortproperty   = 'per_cent_q04'
-                        filterproperty = 'per_cent_q04' )->text( text = 'Column 27' )->ui_template( )->text( text = `{per_cent_q04} %` ).
+                        filterproperty = 'per_cent_q04' )->text( 'Column 27' )->ui_template( )->text( `{per_cent_q04} %` ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_161.clas.abap
+++ b/src/z2ui5_cl_demo_app_161.clas.abap
@@ -52,7 +52,7 @@ CLASS z2ui5_cl_demo_app_161 IMPLEMENTATION.
         afterclose = client->_event( 'BTN_OK_2ND' )
          )->content( ).
 
-    DATA(content) = dialog->label( text = 'this is a second popup' ).
+    DATA(content) = dialog->label( 'this is a second popup' ).
 
     dialog->get_parent( )->buttons(
                   )->button(

--- a/src/z2ui5_cl_demo_app_162.clas.abap
+++ b/src/z2ui5_cl_demo_app_162.clas.abap
@@ -77,7 +77,7 @@ CLASS z2ui5_cl_demo_app_162 IMPLEMENTATION.
     DATA(vbox) = view->vbox( ).
 
     DATA(tab) = vbox->table(
-        items = client->_bind( val = mt_table )
+        client->_bind( val = mt_table )
            )->header_toolbar(
              )->overflow_toolbar(
                  )->toolbar_spacer(
@@ -90,11 +90,11 @@ CLASS z2ui5_cl_demo_app_162 IMPLEMENTATION.
             )->get_parent( )->get_parent( ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_164.clas.abap
+++ b/src/z2ui5_cl_demo_app_164.clas.abap
@@ -66,7 +66,7 @@ CLASS z2ui5_cl_demo_app_164 IMPLEMENTATION.
     DATA(vbox) = view->vbox( ).
 
     DATA(tab) = vbox->table(
-        items = client->_bind( val = mt_table )
+        client->_bind( val = mt_table )
            )->header_toolbar(
              )->overflow_toolbar(
                  )->toolbar_spacer(
@@ -77,11 +77,11 @@ CLASS z2ui5_cl_demo_app_164 IMPLEMENTATION.
             )->get_parent( )->get_parent( ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->text( `{PRODUCT}` ).

--- a/src/z2ui5_cl_demo_app_170.clas.abap
+++ b/src/z2ui5_cl_demo_app_170.clas.abap
@@ -88,7 +88,7 @@ CLASS z2ui5_cl_demo_app_170 IMPLEMENTATION.
         afterclose = client->_event( 'BTN_OK_2ND' )
          )->content( ).
 
-    DATA(content) = dialog->label( text = 'this is a second popup' ).
+    DATA(content) = dialog->label( 'this is a second popup' ).
 
     dialog->get_parent( )->footer( )->overflow_toolbar(
                   )->toolbar_spacer(

--- a/src/z2ui5_cl_demo_app_172.clas.abap
+++ b/src/z2ui5_cl_demo_app_172.clas.abap
@@ -98,7 +98,7 @@ CLASS z2ui5_cl_demo_app_172 IMPLEMENTATION.
         calculate_sum( lv_column ).
     ENDCASE.
 
-    client->follow_up_action( val = `sap.z2ui5.afterBE()` ).
+    client->follow_up_action( `sap.z2ui5.afterBE()` ).
     client->view_model_update( ).
 
   ENDMETHOD.
@@ -130,24 +130,24 @@ CLASS z2ui5_cl_demo_app_172 IMPLEMENTATION.
 
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'TEXT'
-                        filterproperty = 'TEXT' )->text( text = 'Text Column' )->ui_template( )->text( text = `{TEXT}` ).
+                        filterproperty = 'TEXT' )->text( 'Text Column' )->ui_template( )->text( `{TEXT}` ).
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'LINK'
-                        filterproperty = 'LINK' )->text( text = 'Link Column' )->ui_template( )->link( text = `{LINK}`
+                        filterproperty = 'LINK' )->text( 'Link Column' )->ui_template( )->link( text = `{LINK}`
       press                                                                                                 = client->_event( val = 'LINK_CLICK' t_arg = VALUE #( ( `${INDEX}`) ) ) ).
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'CURRENCY'
-                        filterproperty = 'CURRENCY' )->text( text = 'Currency Column' )->ui_template( )->text(
-      text = `{ parts: [ 'CURRENCY', 'WAERS'],  type: 'sap.ui.model.type.Currency', formatOptions: { currencyCode: false } }` ).
+                        filterproperty = 'CURRENCY' )->text( 'Currency Column' )->ui_template( )->text(
+      `{ parts: [ 'CURRENCY', 'WAERS'],  type: 'sap.ui.model.type.Currency', formatOptions: { currencyCode: false } }` ).
     "Formatting of currency is language dependant, f.e. add the parameter &sap-language=DE o your URL to move the euro sign behind the number
 
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'PERCENT1'
-                        filterproperty = 'PERCENT1' )->text( text = 'Percentage' )->ui_template( )->text( text = `{PERCENT1} %` ).
+                        filterproperty = 'PERCENT1' )->text( 'Percentage' )->ui_template( )->text( `{PERCENT1} %` ).
 
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'INPUT1'
-                        filterproperty = 'INPUT1' )->text( text = 'Input Column' )->ui_template( )->input(
+                        filterproperty = 'INPUT1' )->text( 'Input Column' )->ui_template( )->input(
       value           = `{INPUT1}`
       enabled         = `{BOOL}`
       change          = client->_event( val = 'INPUT_CHANGE' t_arg = VALUE #(
@@ -160,7 +160,7 @@ CLASS z2ui5_cl_demo_app_172 IMPLEMENTATION.
 
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'INPUT2'
-                        filterproperty = 'INPUT2' )->text( text = 'Input Column'
+                        filterproperty = 'INPUT2' )->text( 'Input Column'
       )->ui_template(
       )->input(
       value     = `{INPUT2}`
@@ -178,7 +178,7 @@ CLASS z2ui5_cl_demo_app_172 IMPLEMENTATION.
 
     columns->ui_column( width          = '8rem'
                         sortproperty   = 'INPUT3'
-                        filterproperty = 'INPUT3' )->text( text = 'Input Column' )->ui_template( )->input(
+                        filterproperty = 'INPUT3' )->text( 'Input Column' )->ui_template( )->input(
       value           = `{INPUT3}`
       enabled         = `{BOOL}`
       change          = client->_event( val = 'INPUT_CHANGE' t_arg = VALUE #(

--- a/src/z2ui5_cl_demo_app_173.clas.abap
+++ b/src/z2ui5_cl_demo_app_173.clas.abap
@@ -49,12 +49,12 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
              navbuttonpress            = client->_event_nav_app_leave( )
              shownavbutton             = client->check_app_prev_stack( ) ).
 
-    view->table( items = client->_bind( mt_data )
+    view->table( client->_bind( mt_data )
       )->columns(
         )->template_repeat( list = `{template>/MT_LAYOUT}`
                             var  = `L0`
           )->column( mergeduplicates = `{L0>MERGE}`
-                     visible         = `{L0>VISIBLE}` )->text( text = `{L0>FNAME}` )->get_parent(
+                     visible         = `{L0>VISIBLE}` )->text( `{L0>FNAME}` )->get_parent(
         )->get_parent( )->get_parent(
         )->items(
           )->column_list_item(
@@ -64,12 +64,12 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
                 )->object_identifier( text = `{= '{' + ${L1>FNAME} + '}' }` ).
 
 
-    view->label( text = `IF Template (with re-rendering)` ).
+    view->label( `IF Template (with re-rendering)` ).
     view->switch( state  = client->_bind_edit( mv_flag )
                   change = client->_event( `CHANGE_FLAG` ) ).
     view = view->vbox( ).
 
-    view->template_if( test = `{template>/XX/MV_FLAG}`
+    view->template_if( `{template>/XX/MV_FLAG}`
       )->template_then(
         )->icon( src   = `sap-icon://accept`
                  color = `green` )->get_parent(

--- a/src/z2ui5_cl_demo_app_175.clas.abap
+++ b/src/z2ui5_cl_demo_app_175.clas.abap
@@ -35,19 +35,19 @@ CLASS z2ui5_cl_demo_app_175 IMPLEMENTATION.
     DATA(lr_wizard) = lr_view->wizard( ).
     DATA(lr_wiz_step1) = lr_wizard->wizard_step( title     = 'Step1'
                                                  validated = abap_true ).
-    lr_wiz_step1->message_strip( text = 'STEP1' ).
+    lr_wiz_step1->message_strip( 'STEP1' ).
     DATA(lr_wiz_step2) = lr_wizard->wizard_step( title     = 'Step2'
                                                  validated = abap_true ).
 
-    lr_wiz_step2->message_strip( text = 'STEP2' ).
+    lr_wiz_step2->message_strip( 'STEP2' ).
     DATA(lr_wiz_step3) = lr_wizard->wizard_step( title     = 'Step3'
                                                  validated = abap_true ).
 
-    lr_wiz_step3->message_strip( text = 'STEP3' ).
+    lr_wiz_step3->message_strip( 'STEP3' ).
     DATA(lr_wiz_step4) = lr_wizard->wizard_step( title     = 'Step4'
                                                  validated = abap_true ).
 
-    lr_wiz_step4->message_strip( text = 'STEP4' ).
+    lr_wiz_step4->message_strip( 'STEP4' ).
 
     client->view_display( lr_view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_176.clas.abap
+++ b/src/z2ui5_cl_demo_app_176.clas.abap
@@ -70,7 +70,7 @@ CLASS z2ui5_cl_demo_app_176 IMPLEMENTATION.
     DATA(lo_view_nested) = z2ui5_cl_xml_view=>factory( ).
 
     lo_view_nested->shell( )->page( `Nested View`
-      )->table( items = i_client->_bind( mt_data )
+      )->table( i_client->_bind( mt_data )
       )->columns(
         )->template_repeat( list = `{template>/MT_LAYOUT}`
                             var  = `LO`

--- a/src/z2ui5_cl_demo_app_177.clas.abap
+++ b/src/z2ui5_cl_demo_app_177.clas.abap
@@ -99,7 +99,7 @@ CLASS z2ui5_cl_demo_app_177 IMPLEMENTATION.
                 text  = 'letf side button'
                 icon  = 'sap-icon://account'
                 press = client->_event( 'BUTTON_SORT' )
-            )->segmented_button( selected_key = mv_key
+            )->segmented_button( mv_key
                 )->items(
                     )->segmented_button_item(
                         key  = 'BLUE'

--- a/src/z2ui5_cl_demo_app_179.clas.abap
+++ b/src/z2ui5_cl_demo_app_179.clas.abap
@@ -245,8 +245,8 @@ CLASS Z2UI5_CL_DEMO_APP_179 IMPLEMENTATION.
                  '    "wrap": true}'
       ).
 
-    column->text( text = `Object Name` ).
-    column->tree_template( )->label( text = `{OBJECTNAME}` ).
+    column->text( `Object Name` ).
+    column->tree_template( )->label( `{OBJECTNAME}` ).
 
     gantt->axis_time_strategy(
       )->proportion_zoom_strategy(

--- a/src/z2ui5_cl_demo_app_180.clas.abap
+++ b/src/z2ui5_cl_demo_app_180.clas.abap
@@ -28,7 +28,7 @@ CLASS Z2UI5_CL_DEMO_APP_180 IMPLEMENTATION.
     IF client->check_on_event( 'CALL_EF' ).
       mv_url = `https://www.google.com`.
       client->view_model_update( ).
-      client->follow_up_action( val = client->_event_client( val = client->cs_event-open_new_tab t_arg = VALUE #( ( mv_url ) ) ) ).
+      client->follow_up_action( client->_event_client( val = client->cs_event-open_new_tab t_arg = VALUE #( ( mv_url ) ) ) ).
     ENDIF.
 
   ENDMETHOD.
@@ -45,8 +45,8 @@ CLASS Z2UI5_CL_DEMO_APP_180 IMPLEMENTATION.
     page = page->vbox( ).
     page->button( text  = `call frontend event from backend event`
                   press = client->_event( `CALL_EF` ) ).
-    page->label( text = `MV_URL was set AFTER backend event and model update to:` ).
-    page->label( text = client->_bind_edit( mv_url ) ).
+    page->label( `MV_URL was set AFTER backend event and model update to:` ).
+    page->label( client->_bind_edit( mv_url ) ).
 
     client->view_display( view->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_181.clas.abap
+++ b/src/z2ui5_cl_demo_app_181.clas.abap
@@ -77,12 +77,12 @@ CLASS z2ui5_cl_demo_app_181 IMPLEMENTATION.
 
     DATA(card_1) = page->card( width = `300px`
                                class = `sapUiMediumMargin`
-      )->header( ns = `f`
+      )->header( `f`
         )->card_header( title    = `Buy bus ticket on-line`
                         subtitle = `Buy a single-ride ticket for a date`
                         iconsrc  = `sap-icon://bus-public-transport`
                       )->get_parent( )->get_parent(
-                    )->content( ns = `f`
+                    )->content( `f`
                       )->vbox( height         = `110px`
                                class          = `sapUiSmallMargin`
                                justifycontent = `SpaceBetween`
@@ -110,21 +110,21 @@ CLASS z2ui5_cl_demo_app_181 IMPLEMENTATION.
 
     DATA(card_2) = page->card( width = `300px`
                                class = `sapUiMediumMargin`
-                     )->header( ns = `f`
+                     )->header( `f`
                        )->card_header( title    = `Project Cloud Transformation`
                                        subtitle = `Revenue per Product | EUR`
                                      )->get_parent( )->get_parent(
-                                   )->content( ns = `f`
+                                   )->content( `f`
                                     )->list( class          = `sapUiSmallMarginBottom`
                                              showseparators = `None`
                                              items          = client->_bind( mt_products )
                                        )->custom_list_item(
                                         )->hbox( alignitems     = `Center`
                                                  justifycontent = `SpaceBetween`
-                                          )->vbox( class = `sapUiSmallMarginBegin sapUiSmallMarginTopBottom`
+                                          )->vbox( `sapUiSmallMarginBegin sapUiSmallMarginTopBottom`
                                             )->title( text       = `{TITLE}`
                                                       titlestyle = `H3`
-                                            )->text( text = `{SUBTITLE}`
+                                            )->text( `{SUBTITLE}`
                                           )->get_parent(
                                           )->object_status( class = `sapUiTinyMargin sapUiSmallMarginEnd`
                                                             text  = `{REVENUE}`

--- a/src/z2ui5_cl_demo_app_182.clas.abap
+++ b/src/z2ui5_cl_demo_app_182.clas.abap
@@ -128,7 +128,7 @@ CLASS Z2UI5_CL_DEMO_APP_182 IMPLEMENTATION.
                                                                                      nodespacing   = `40`
                                      )->get_parent(
                                      )->get_parent(
-                                  )->nodes( ns = `networkgraph`
+                                  )->nodes( `networkgraph`
                                     )->node( icon                  = `sap-icon://action-settings`
                                              key                   = `{ID}`
                                              description           = `{TITLE}`
@@ -149,7 +149,7 @@ CLASS Z2UI5_CL_DEMO_APP_182 IMPLEMENTATION.
 *                                                                                        )->core_custom_data( key = `phone` value = `{PHONE}`
 *                                           )->get_parent(
 *                                           )->get( )->get_parent( )->get_parent( )->attributes( ns = `networkgraph`
-                                           )->get( )->attributes( ns = `networkgraph`
+                                           )->get( )->attributes( `networkgraph`
                                             )->element_attribute( label = `{LABEL}`
                                                                   value = `{VALUE}`
                                            )->get_parent(

--- a/src/z2ui5_cl_demo_app_183.clas.abap
+++ b/src/z2ui5_cl_demo_app_183.clas.abap
@@ -100,7 +100,7 @@ CLASS z2ui5_cl_demo_app_183 IMPLEMENTATION.
                 text  = 'letf side button'
                 icon  = 'sap-icon://account'
                 press = client->_event( 'BUTTON_SORT' )
-            )->segmented_button( selected_key = mv_key
+            )->segmented_button( mv_key
                 )->items(
                     )->segmented_button_item(
                         key  = 'BLUE'
@@ -126,14 +126,14 @@ CLASS z2ui5_cl_demo_app_183 IMPLEMENTATION.
 *      )->column_menu_quick_sort( change = client->_event( val = 'ONSORT' t_arg = VALUE #( ( `${$parameters>/item.getKey}` ) ) )
 *      )->column_menu_quick_sort( change = client->_event( val = 'ONSORT' t_arg = VALUE #( ( `$event` ) ) )
        )->column_menu_quick_sort( change = client->_event( 'ONSORT' )
-         )->items( ns = `columnmenu`
+         )->items( `columnmenu`
            )->column_menu_quick_sort_item( sortorder = client->_bind_edit( sortorder )
        )->get_parent( )->get_parent( )->get_parent(
        )->column_menu_quick_group( change = client->_event( 'ONGROUP' )
-         )->items( ns = `columnmenu`
+         )->items( `columnmenu`
            )->column_menu_quick_group_item(
        )->get_parent( )->get_parent( )->get_parent(
-       )->items( ns = `columnmenu`
+       )->items( `columnmenu`
          )->column_menu_action_item( icon  = `sap-icon://sort`
                                      label = `Sort`
                                      press = client->_event( 'ONSORTACTIONITEM' ) )->get_parent(

--- a/src/z2ui5_cl_demo_app_186.clas.abap
+++ b/src/z2ui5_cl_demo_app_186.clas.abap
@@ -47,7 +47,7 @@ CLASS Z2UI5_CL_DEMO_APP_186 IMPLEMENTATION.
   METHOD on_event.
 
     IF client->check_on_event( 'BUTTON_DOWNLOAD' ).
-      client->follow_up_action( val = client->_event_client( val = client->cs_event-download_b64_file t_arg = VALUE #( ( file_content_64 ) ( file_name ) ) ) ).
+      client->follow_up_action( client->_event_client( val = client->cs_event-download_b64_file t_arg = VALUE #( ( file_content_64 ) ( file_name ) ) ) ).
     ENDIF.
 
   ENDMETHOD.
@@ -71,7 +71,7 @@ CLASS Z2UI5_CL_DEMO_APP_186 IMPLEMENTATION.
                     height         = `600px`
                     alignitems     = `Center`
                     justifycontent = `SpaceAround`
-      )->vbox( )->text( text = `Base64 String:`
+      )->vbox( )->text( `Base64 String:`
       )->text_area( value    = client->_bind_edit( file_content_64 )
                     rows     = `20`
                     width    = `800px`
@@ -79,7 +79,7 @@ CLASS Z2UI5_CL_DEMO_APP_186 IMPLEMENTATION.
       )->get_parent(
       )->vbox( justifycontent = `Center`
                alignitems     = `Center`
-      )->text( text = `fill filename:`
+      )->text( `fill filename:`
       )->input( value = client->_bind_edit( file_name )
                 class = `sapUiLargeMarginBottom`
                 width = `15rem`

--- a/src/z2ui5_cl_demo_app_189.clas.abap
+++ b/src/z2ui5_cl_demo_app_189.clas.abap
@@ -46,7 +46,7 @@ CLASS z2ui5_cl_demo_app_189 IMPLEMENTATION.
               shownavbutton  = client->check_app_prev_stack( ) ).
 
     page->simple_form(
-       )->content( ns = 'form'
+       )->content( 'form'
        )->label( 'One (Press Enter)' )->input( id     = 'IdOne'
                                                value  = client->_bind_edit( one )
                                                submit = client->_event( 'one_enter' )
@@ -56,7 +56,7 @@ CLASS z2ui5_cl_demo_app_189 IMPLEMENTATION.
        )->label( 'Three' )->input( id    = 'IdThree'
                                    value = client->_bind_edit( three ) ).
 
-    page->_z2ui5( )->focus( focusid = client->_bind( focus_field ) ).
+    page->_z2ui5( )->focus( client->_bind( focus_field ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_192.clas.abap
+++ b/src/z2ui5_cl_demo_app_192.clas.abap
@@ -89,7 +89,7 @@ CLASS z2ui5_cl_demo_app_192 IMPLEMENTATION.
       INSERT lo_new_data INTO TABLE mt_new_data2.
 
       lr_structdescr ?= cl_abap_structdescr=>describe_by_data( <fs_s_head> ).
-      lr_tabdescr ?= cl_abap_tabledescr=>create( p_line_type = lr_structdescr ).
+      lr_tabdescr ?= cl_abap_tabledescr=>create( lr_structdescr ).
 
       CREATE DATA lo_new_data->mt_kopf TYPE HANDLE lr_tabdescr.
       ASSIGN lo_new_data->mt_kopf->* TO <fs_t_head_new>.

--- a/src/z2ui5_cl_demo_app_194.clas.abap
+++ b/src/z2ui5_cl_demo_app_194.clas.abap
@@ -53,7 +53,7 @@ CLASS z2ui5_cl_demo_app_194 IMPLEMENTATION.
           CONTINUE.
         ELSE.
 
-          client->_bind( val = <val> ).
+          client->_bind( <val> ).
 
         ENDIF.
 

--- a/src/z2ui5_cl_demo_app_196.clas.abap
+++ b/src/z2ui5_cl_demo_app_196.clas.abap
@@ -133,7 +133,7 @@ CLASS Z2UI5_CL_DEMO_APP_196 IMPLEMENTATION.
 
     DATA(panel) = page->panel( class = `sapUiResponsiveMargin SIPanelStyle`
                                width = `95%` ).
-    panel->text( text = `Use the slider for adjusting the fill` ).
+    panel->text( `Use the slider for adjusting the fill` ).
     panel->slider( class           = `sapUiLargeMarginBottom`
                    enabletickmarks = abap_true
                value               = client->_bind_edit( mv_slider_value ) )->get(

--- a/src/z2ui5_cl_demo_app_197.clas.abap
+++ b/src/z2ui5_cl_demo_app_197.clas.abap
@@ -64,11 +64,11 @@ CLASS Z2UI5_CL_DEMO_APP_197 IMPLEMENTATION.
                              items = client->_bind_edit( val = mt_table ) ).
 
     DATA(lo_columns) = tab->columns( ).
-    lo_columns->column( )->text( text = `Product` ).
-    lo_columns->column( )->text( text = `Date` ).
-    lo_columns->column( )->text( text = `Name` ).
-    lo_columns->column( )->text( text = `Location` ).
-    lo_columns->column( )->text( text = `Quantity` ).
+    lo_columns->column( )->text( `Product` ).
+    lo_columns->column( )->text( `Date` ).
+    lo_columns->column( )->text( `Name` ).
+    lo_columns->column( )->text( `Location` ).
+    lo_columns->column( )->text( `Quantity` ).
 
     DATA(lo_cells) = tab->items( )->column_list_item( ).
     lo_cells->link( id    = `link`

--- a/src/z2ui5_cl_demo_app_201.clas.abap
+++ b/src/z2ui5_cl_demo_app_201.clas.abap
@@ -340,13 +340,13 @@ CLASS Z2UI5_CL_DEMO_APP_201 IMPLEMENTATION.
                  )->get( ).
 
     input->suggestion_columns(
-        )->column( )->label( text = 'Name' )->get_parent(
-        )->column( )->label( text = 'Currency' ).
+        )->column( )->label( 'Name' )->get_parent(
+        )->column( )->label( 'Currency' ).
 
     input->suggestion_rows(
         )->column_list_item(
-            )->label( text = '{CURRENCYNAME}'
-            )->label( text = '{CURRENCY}' ).
+            )->label( '{CURRENCYNAME}'
+            )->label( '{CURRENCY}' ).
 
     page->_generic( name = `script`
                     ns   = `html` )->_cc_plain_xml( `setInputFIlter()` ).

--- a/src/z2ui5_cl_demo_app_202.clas.abap
+++ b/src/z2ui5_cl_demo_app_202.clas.abap
@@ -44,7 +44,7 @@ CLASS Z2UI5_CL_DEMO_APP_202 IMPLEMENTATION.
     DATA(lr_wiz_step1) = lr_wizard->wizard_step( title     = 'STEP1'
                                                  validated = abap_true
                                                  nextstep  = 'STEP2' ).
-    lr_wiz_step1->message_strip( text = 'STEP1' ).
+    lr_wiz_step1->message_strip( 'STEP1' ).
 
 
     DATA(lr_wiz_step2) = lr_wizard->wizard_step( id              = 'STEP2'
@@ -52,7 +52,7 @@ CLASS Z2UI5_CL_DEMO_APP_202 IMPLEMENTATION.
                                                  validated       = abap_true
                                                  subsequentsteps = 'STEP22, STEP23' ).
 
-    lr_wiz_step2->message_strip( text = `STEP2` ).
+    lr_wiz_step2->message_strip( `STEP2` ).
     lr_wiz_step2->button(
 *      EXPORTING
         text  = `Press Step 2.2`
@@ -67,20 +67,20 @@ CLASS Z2UI5_CL_DEMO_APP_202 IMPLEMENTATION.
                                                  title     = `STEP2.2`
                                                  validated = abap_true ).
 
-    lr_wiz_step22->message_strip( text = 'STEP22' ).
+    lr_wiz_step22->message_strip( 'STEP22' ).
 
 
     DATA(lr_wiz_step23) = lr_wizard->wizard_step( id       = `STEP23`
                                                  title     = `STEP2.3`
                                                  validated = abap_true ).
 
-    lr_wiz_step23->message_strip( text = 'STEP23' ).
+    lr_wiz_step23->message_strip( 'STEP23' ).
 
 
     DATA(lr_wiz_step3) = lr_wizard->wizard_step( title     = `STEP3`
                                                  validated = abap_true ).
 
-    lr_wiz_step3->message_strip( text = 'STEP3' ).
+    lr_wiz_step3->message_strip( 'STEP3' ).
 
 *
     client->view_display( lr_view->stringify( ) ).
@@ -100,11 +100,11 @@ CLASS Z2UI5_CL_DEMO_APP_202 IMPLEMENTATION.
     CASE client->get( )-event.
       WHEN 'STEP22'.
 
-        client->follow_up_action( val = 'sap.z2ui5.decideNextStep(`STEP2`,`STEP22`);' ).
+        client->follow_up_action( 'sap.z2ui5.decideNextStep(`STEP2`,`STEP22`);' ).
 
       WHEN 'STEP23'.
 
-        client->follow_up_action( val = 'sap.z2ui5.decideNextStep(`STEP2`,`STEP23`);' ).
+        client->follow_up_action( 'sap.z2ui5.decideNextStep(`STEP2`,`STEP23`);' ).
 
     ENDCASE.
     client->view_model_update( ).

--- a/src/z2ui5_cl_demo_app_206.clas.abap
+++ b/src/z2ui5_cl_demo_app_206.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_demo_app_206 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout( class = `sapUiContentPadding`
                                           width = `100%` ).
 
-    layout->text( text = `Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
+    layout->text( `Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
                   `At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. ` &&
                   `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
                   `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat` )->get_parent( )->get_parent( ).

--- a/src/z2ui5_cl_demo_app_207.clas.abap
+++ b/src/z2ui5_cl_demo_app_207.clas.abap
@@ -30,7 +30,7 @@ CLASS Z2UI5_CL_DEMO_APP_207 IMPLEMENTATION.
             navbuttonpress = client->_event_nav_app_leave( )
             shownavbutton  = client->check_app_prev_stack( ) ).
 
-    DATA(layout) = page->vbox( class = `sapUiSmallMargin`
+    DATA(layout) = page->vbox( `sapUiSmallMargin`
                           )->label( text     = `Default RadioButton use`
                                     labelfor = `GroupA`
                           )->radio_button_group( id = `GroupA`
@@ -40,10 +40,10 @@ CLASS Z2UI5_CL_DEMO_APP_207 IMPLEMENTATION.
                               )->radio_button( text = `Option 3` )->get_parent(
                               )->radio_button( text = `Option 4` )->get_parent(
                               )->radio_button( text = `Option 5` )->get_parent( )->get_parent( )->get_parent(
-                      )->vbox( class = `sapUiSmallMargin`
-                          )->label( text = `RadioButton in various ValueState variants`
+                      )->vbox( `sapUiSmallMargin`
+                          )->label( `RadioButton in various ValueState variants`
                           )->hbox( class = `sapUiTinyMarginTopBottom`
-                              )->vbox( class = `sapUiMediumMarginEnd`
+                              )->vbox( `sapUiMediumMarginEnd`
                                   )->label( text     = `Success`
                                             labelfor = `GroupB`
                                   )->radio_button_group( id         = `GroupB`
@@ -51,7 +51,7 @@ CLASS Z2UI5_CL_DEMO_APP_207 IMPLEMENTATION.
                                       )->radio_button( text     = `Option 1`
                                                        selected = abap_true )->get_parent(
                                       )->radio_button( text = `Option 2` )->get_parent( )->get_parent( )->get_parent(
-                              )->vbox( class = `sapUiMediumMarginEnd`
+                              )->vbox( `sapUiMediumMarginEnd`
                                   )->label( text     = `Error`
                                             labelfor = `GroupC`
                                   )->radio_button_group( id         = `GroupC`
@@ -59,7 +59,7 @@ CLASS Z2UI5_CL_DEMO_APP_207 IMPLEMENTATION.
                                       )->radio_button( text     = `Option 1`
                                                        selected = abap_true )->get_parent(
                                       )->radio_button( text = `Option 2` )->get_parent( )->get_parent( )->get_parent(
-                              )->vbox( class = `sapUiMediumMarginEnd`
+                              )->vbox( `sapUiMediumMarginEnd`
                                   )->label( text     = `Warning`
                                             labelfor = `GroupD`
                                   )->radio_button_group( id         = `GroupD`
@@ -67,7 +67,7 @@ CLASS Z2UI5_CL_DEMO_APP_207 IMPLEMENTATION.
                                       )->radio_button( text     = `Option 1`
                                                        selected = abap_true )->get_parent(
                                       )->radio_button( text = `Option 2` )->get_parent( )->get_parent( )->get_parent(
-                              )->vbox( class = `sapUiMediumMarginEnd`
+                              )->vbox( `sapUiMediumMarginEnd`
                                   )->label( text     = `Information`
                                             labelfor = `GroupE`
                                   )->radio_button_group( id         = `GroupE`

--- a/src/z2ui5_cl_demo_app_208.clas.abap
+++ b/src/z2ui5_cl_demo_app_208.clas.abap
@@ -30,7 +30,7 @@ CLASS Z2UI5_CL_DEMO_APP_208 IMPLEMENTATION.
             navbuttonpress = client->_event_nav_app_leave( )
             shownavbutton  = client->check_app_prev_stack( ) ).
 
-    DATA(layout) = page->vbox( class = `sapUiSmallMargin`
+    DATA(layout) = page->vbox( `sapUiSmallMargin`
                           )->label( labelfor = `rbg1`
                                     text     = `An example with 'matrix' layout`
                           )->radio_button_group( id      = `rbg1`

--- a/src/z2ui5_cl_demo_app_212.clas.abap
+++ b/src/z2ui5_cl_demo_app_212.clas.abap
@@ -117,7 +117,7 @@ CLASS z2ui5_cl_demo_app_212 IMPLEMENTATION.
     DATA(content) = popup->dialog( contentwidth = '60%'
           )->simple_form( layout   = 'ResponsiveGridLayout'
                           editable = abap_true
-          )->content( ns = 'form' ).
+          )->content( 'form' ).
 
     " Gehe über alle Comps wenn wir im Edit sind dann sind keyfelder nicht eingabebereit.
     LOOP AT mt_dfies REFERENCE INTO DATA(dfies).
@@ -130,7 +130,7 @@ CLASS z2ui5_cl_demo_app_212 IMPLEMENTATION.
 
 
 
-      content->label( text = `text` ).
+      content->label( `text` ).
 
       content->input( value       = client->_bind_edit( <val> )
                     enabled       = abap_false

--- a/src/z2ui5_cl_demo_app_217.clas.abap
+++ b/src/z2ui5_cl_demo_app_217.clas.abap
@@ -32,10 +32,10 @@ CLASS z2ui5_cl_demo_app_217 IMPLEMENTATION.
 
     DATA(layout) = page->overflow_toolbar( design = `Transparent`
                                            height = `3rem`
-                          )->title( text = `Title Only` ).
+                          )->title( `Title Only` ).
     page->overflow_toolbar( design = `Transparent`
                             height = `3rem`
-                          )->title( text = `Title and Actions`
+                          )->title( `Title and Actions`
                           )->toolbar_spacer(
                           )->button( icon = `sap-icon://group-2`
                           )->button( icon = `sap-icon://action-settings` ).

--- a/src/z2ui5_cl_demo_app_219.clas.abap
+++ b/src/z2ui5_cl_demo_app_219.clas.abap
@@ -31,23 +31,23 @@ CLASS z2ui5_cl_demo_app_219 IMPLEMENTATION.
             shownavbutton  = client->check_app_prev_stack( ) ).
 
     DATA(layout) = page->list( headertext = `Input`
-                           )->input_list_item( label = `WLAN`
+                           )->input_list_item( `WLAN`
                                )->switch( state = `true` )->get_parent(
-                           )->input_list_item( label = `Flight Mode`
-                               )->checkbox( selected = `true` )->get_parent(
-                           )->input_list_item( label = `High Performance`
+                           )->input_list_item( `Flight Mode`
+                               )->checkbox( `true` )->get_parent(
+                           )->input_list_item( `High Performance`
                                )->radio_button( groupname = `GroupInputListItem`
                                                 selected  = abap_true )->get_parent( )->get_parent(
-                           )->input_list_item( label = `Battery Saving`
+                           )->input_list_item( `Battery Saving`
                                )->radio_button( groupname = `GroupInputListItem` )->get_parent( )->get_parent(
-                           )->input_list_item( label = `Price (EUR)`
+                           )->input_list_item( `Price (EUR)`
                                )->input( placeholder = `Price`
                                          value       = `799`
                                          type        = `Number` )->get_parent(
-                           )->input_list_item( label = `Address`
+                           )->input_list_item( `Address`
                                )->input( placeholder = `Address`
                                          value       = `Main Rd, Manchester` )->get_parent(
-                           )->input_list_item( label = `Country`
+                           )->input_list_item( `Country`
                                )->select(
                                    )->item( key  = `GR`
                                             text = `Greece`
@@ -59,7 +59,7 @@ CLASS z2ui5_cl_demo_app_219 IMPLEMENTATION.
                                             text = `New Zealand`
                                    )->item( key  = `NL`
                                             text = `Netherlands` )->get_parent( )->get_parent(
-                           )->input_list_item( label = `Volume`
+                           )->input_list_item( `Volume`
                                )->slider( min   = `0`
                                           max   = `10`
                                           value = `7`

--- a/src/z2ui5_cl_demo_app_221.clas.abap
+++ b/src/z2ui5_cl_demo_app_221.clas.abap
@@ -36,18 +36,18 @@ CLASS z2ui5_cl_demo_app_221 IMPLEMENTATION.
                           )->items(
                               )->icon_tab_filter( icon = `sap-icon://hint`
                                                   key  = `info`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_filter( icon  = `sap-icon://attachment`
                                                   key   = `attachments`
                                                   count = `3`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_filter( icon  = `sap-icon://notes`
                                                   key   = `notes`
                                                   count = `12`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_filter( icon = `sap-icon://group`
                                                   key  = `people`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_222.clas.abap
+++ b/src/z2ui5_cl_demo_app_222.clas.abap
@@ -37,19 +37,19 @@ CLASS z2ui5_cl_demo_app_222 IMPLEMENTATION.
                               )->icon_tab_filter( text  = `Info`
                                                   key   = `info`
                                                   count = `3`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_filter( text  = `Attachments`
                                                   key   = `attachments`
                                                   count = `4321`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_filter( text  = `Notes`
                                                   key   = `notes`
                                                   count = `333`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_filter( text  = `People`
                                                   key   = `people`
                                                   count = `34`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_223.clas.abap
+++ b/src/z2ui5_cl_demo_app_223.clas.abap
@@ -38,19 +38,19 @@ CLASS z2ui5_cl_demo_app_223 IMPLEMENTATION.
                               )->icon_tab_filter( text  = `Info`
                                                   key   = `info`
                                                   count = `3`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_filter( text  = `Attachments`
                                                   key   = `attachments`
                                                   count = `4321`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_filter( text  = `Notes`
                                                   key   = `notes`
                                                   count = `333`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_filter( text  = `People`
                                                   key   = `people`
                                                   count = `34`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_224.clas.abap
+++ b/src/z2ui5_cl_demo_app_224.clas.abap
@@ -36,16 +36,16 @@ CLASS z2ui5_cl_demo_app_224 IMPLEMENTATION.
                           )->items(
                               )->icon_tab_filter( text = `Info`
                                                   key  = `info`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_filter( text = `Attachments`
                                                   key  = `attachments`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_filter( text = `Notes`
                                                   key  = `notes`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_filter( text = `People`
                                                   key  = `people`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_225.clas.abap
+++ b/src/z2ui5_cl_demo_app_225.clas.abap
@@ -41,22 +41,22 @@ CLASS z2ui5_cl_demo_app_225 IMPLEMENTATION.
                               )->icon_tab_filter( key       = `info`
                                                   icon      = `sap-icon://hint`
                                                   iconcolor = `Neutral`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_separator( icon = `` )->get_parent(
                               )->icon_tab_filter( key       = `attachments`
                                                   icon      = `sap-icon://attachment`
                                                   iconcolor = `Neutral`
                                                   count     = `3`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_filter( key   = `notes`
                                                   icon  = `sap-icon://notes`
                                                   count = `12`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_separator( icon = `` )->get_parent(
                               )->icon_tab_filter( key       = `people`
                                                   icon      = `sap-icon://group`
                                                   iconcolor = `Negative`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     layout->label( wrapping           = `true`
                                 text  = `Icon used as separator, you are free to choose an icon you want.`
@@ -69,23 +69,23 @@ CLASS z2ui5_cl_demo_app_225 IMPLEMENTATION.
                               )->icon_tab_filter( key       = `info`
                                                   icon      = `sap-icon://hint`
                                                   iconcolor = `Neutral`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_filter( key       = `attachments`
                                                   icon      = `sap-icon://attachment`
                                                   iconcolor = `Neutral`
                                                   count     = `3`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_separator( icon = `sap-icon://process` )->get_parent(
                               )->icon_tab_filter( key       = `notes`
                                                   icon      = `sap-icon://notes`
                                                   iconcolor = `Positive`
                                                   count     = `12`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
                               )->icon_tab_separator( icon = `sap-icon://process` )->get_parent(
                               )->icon_tab_filter( key       = `people`
                                                   icon      = `sap-icon://group`
                                                   iconcolor = `Negative`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     layout->label( wrapping           = `true`
                                 text  = `Different separators used.`
@@ -98,24 +98,24 @@ CLASS z2ui5_cl_demo_app_225 IMPLEMENTATION.
                               )->icon_tab_filter( key       = `info`
                                                   icon      = `sap-icon://hint`
                                                   iconcolor = `Critical`
-                                                  )->text( text = `Info content goes here ...` )->get_parent(
+                                                  )->text( `Info content goes here ...` )->get_parent(
                               )->icon_tab_separator( icon = `` )->get_parent(
                               )->icon_tab_filter( key       = `info`
                                                   icon      = `sap-icon://attachment`
                                                   iconcolor = `Neutral`
                                                   count     = `3`
-                                                  )->text( text = `Attachments go here ...` )->get_parent(
+                                                  )->text( `Attachments go here ...` )->get_parent(
                               )->icon_tab_separator( icon = `sap-icon://vertical-grip` )->get_parent(
                               )->icon_tab_filter( key       = `notes`
                                                   icon      = `sap-icon://notes`
                                                   iconcolor = `Positive`
                                                   count     = `12`
-                                                  )->text( text = `Notes go here ...` )->get_parent(
+                                                  )->text( `Notes go here ...` )->get_parent(
       )->icon_tab_separator( icon = `sap-icon://process` )->get_parent(
                               )->icon_tab_filter( key       = `people`
                                                   icon      = `sap-icon://group`
                                                   iconcolor = `Negative`
-                                                  )->text( text = `People content goes here ...` ).
+                                                  )->text( `People content goes here ...` ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_226.clas.abap
+++ b/src/z2ui5_cl_demo_app_226.clas.abap
@@ -41,32 +41,32 @@ CLASS z2ui5_cl_demo_app_226 IMPLEMENTATION.
                                       text = `Info`
                       )->items(
                           )->icon_tab_filter( text = `Info one`
-                              )->text( text = `Info one content goes here...`
-                              )->text( text = `Select another sub tab to see its content...` )->get_parent(
+                              )->text( `Info one content goes here...`
+                              )->text( `Select another sub tab to see its content...` )->get_parent(
                           )->icon_tab_filter( text = `Info two`
-                              )->text( text = `Info two content goes here...` )->get_parent(
+                              )->text( `Info two content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Info three`
-                              )->text( text = `Info three content goes here...` )->get_parent(
+                              )->text( `Info three content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Info four`
-                              )->text( text = `Info four content goes here...` )->get_parent( )->get_parent(
-                      )->text( text = `Info own content goes here...`
-                      )->text( text = `Select a sub tab to see its content...` )->get_parent(
+                              )->text( `Info four content goes here...` )->get_parent( )->get_parent(
+                      )->text( `Info own content goes here...`
+                      )->text( `Select a sub tab to see its content...` )->get_parent(
       )->icon_tab_filter( key  = `attachments`
                           text = `Attachments`
                       )->items(
                           )->icon_tab_filter( text = `Attachment one`
-                              )->text( text = `Attachment one goes here...` )->get_parent(
+                              )->text( `Attachment one goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Attachment two`
-                              )->text( text = `Attachment two goes here...` )->get_parent( )->get_parent(
-                      )->text( text = `Attachments own content goes here...` )->get_parent(
+                              )->text( `Attachment two goes here...` )->get_parent( )->get_parent(
+                      )->text( `Attachments own content goes here...` )->get_parent(
       )->icon_tab_filter( key  = `notes`
                           text = `Notes`
                       )->items(
                           )->icon_tab_filter( text = `Note one`
-                              )->text( text = `Note one goes here...` )->get_parent(
+                              )->text( `Note one goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Note two`
-                              )->text( text = `Note two goes here...` )->get_parent( )->get_parent(
-                      )->text( text = `Notes own content goes here...` )->get_parent( )->get_parent( )->get_parent(
+                              )->text( `Note two goes here...` )->get_parent( )->get_parent(
+                      )->text( `Notes own content goes here...` )->get_parent( )->get_parent( )->get_parent(
       )->label(
                 wrapping = `true`
                 text     = `IconTabBar with filters without own content - only sub tabs`
@@ -77,27 +77,27 @@ CLASS z2ui5_cl_demo_app_226 IMPLEMENTATION.
                                       text = `Info`
                       )->items(
                           )->icon_tab_filter( text = `Info one`
-                              )->text( text = `Info one content goes here...` )->get_parent(
+                              )->text( `Info one content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Info two`
-                              )->text( text = `Info two content goes here...` )->get_parent(
+                              )->text( `Info two content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Info three`
-                              )->text( text = `Info three content goes here...` )->get_parent(
+                              )->text( `Info three content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Info four`
-                              )->text( text = `Info four content goes here...` )->get_parent( )->get_parent( )->get_parent(
+                              )->text( `Info four content goes here...` )->get_parent( )->get_parent( )->get_parent(
       )->icon_tab_filter( key  = `attachments`
                           text = `Attachments`
                       )->items(
                           )->icon_tab_filter( text = `Attachment one`
-                              )->text( text = `Attachment one goes here...` )->get_parent(
+                              )->text( `Attachment one goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Attachment two`
-                              )->text( text = `Attachment two goes here...` )->get_parent( )->get_parent( )->get_parent(
+                              )->text( `Attachment two goes here...` )->get_parent( )->get_parent( )->get_parent(
       )->icon_tab_filter( key  = `notes`
                           text = `Notes`
                       )->items(
                           )->icon_tab_filter( text = `Note one`
-                              )->text( text = `Note one content goes here...` )->get_parent(
+                              )->text( `Note one content goes here...` )->get_parent(
                           )->icon_tab_filter( text = `Note two`
-                              )->text( text = `Note two content goes here...` )->get_parent( )->get_parent( ).
+                              )->text( `Note two content goes here...` )->get_parent( )->get_parent( ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_227.clas.abap
+++ b/src/z2ui5_cl_demo_app_227.clas.abap
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_demo_app_227 IMPLEMENTATION.
                                       )->search_field( )->get_parent( )->get_parent(
                               )->content(
                                   )->vbox(
-                                      )->text( text = `Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore ` &&
+                                      )->text( `Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore ` &&
                                                       `et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. ` &&
                                                       `Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit ` &&
                                                       `amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam ` &&

--- a/src/z2ui5_cl_demo_app_228.clas.abap
+++ b/src/z2ui5_cl_demo_app_228.clas.abap
@@ -30,7 +30,7 @@ CLASS z2ui5_cl_demo_app_228 IMPLEMENTATION.
             navbuttonpress = client->_event_nav_app_leave( )
             shownavbutton  = client->check_app_prev_stack( ) ).
 
-    DATA(layout) = page->label( text = `Numeric content with margins` ).
+    DATA(layout) = page->label( `Numeric content with margins` ).
     layout->numeric_content( value      = `65.5`
                              scale      = `MM`
                              class      = `sapUiSmallMargin`
@@ -54,7 +54,7 @@ CLASS z2ui5_cl_demo_app_228 IMPLEMENTATION.
                              class      = `sapUiSmallMargin`
                              withmargin = abap_true ).
 
-    layout->label( text = `Numeric content without margins` ).
+    layout->label( `Numeric content without margins` ).
     layout->numeric_content( value      = `65.5`
                              scale      = `MM`
                              class      = `sapUiSmallMargin`

--- a/src/z2ui5_cl_demo_app_230.clas.abap
+++ b/src/z2ui5_cl_demo_app_230.clas.abap
@@ -32,8 +32,8 @@ CLASS z2ui5_cl_demo_app_230 IMPLEMENTATION.
 
     DATA(layout) = page->list(
                           headertext = `Input List Item`
-                          )->input_list_item( label = `Battery Saving`
-                              )->segmented_button( selected_key = `SBYes`
+                          )->input_list_item( `Battery Saving`
+                              )->segmented_button( `SBYes`
                                   )->items(
                                       )->segmented_button_item( text = `High`
                                                                 key  = `SBYes`

--- a/src/z2ui5_cl_demo_app_234.clas.abap
+++ b/src/z2ui5_cl_demo_app_234.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_demo_app_234 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout(
                          class = `sapUiContentPadding`
                          width = `100%`
-                          )->content( ns = `layout`
+                          )->content( `layout`
                               )->text_area( valuestate  = `Warning`
                                             placeholder = `ValueState : Warning`
                                             width       = `100%`

--- a/src/z2ui5_cl_demo_app_235.clas.abap
+++ b/src/z2ui5_cl_demo_app_235.clas.abap
@@ -49,14 +49,14 @@ CLASS z2ui5_cl_demo_app_235 IMPLEMENTATION.
                              )->message_strip( text  = `A Toolbar's centering technique will be slightly off the center if there is a button on the left.`
                                                class = `sapUiTinyMargin`
                              )->toolbar(
-                                 )->label( text = `Toolbar can shrink content in case of overflow.`
+                                 )->label( `Toolbar can shrink content in case of overflow.`
                                      )->layout_data(
                                          )->toolbar_layout_data( shrinkable = abap_false )->get_parent( )->get_parent(
                                  )->button( text = `Accept`
                                             type = `Accept`
                                      )->layout_data(
                                          )->toolbar_layout_data( shrinkable = abap_true )->get_parent( )->get_parent(
-                                 )->label( text = `This is a long non-shrinkable label.`
+                                 )->label( `This is a long non-shrinkable label.`
                                      )->layout_data(
                                          )->toolbar_layout_data( shrinkable = abap_false )->get_parent( )->get_parent(
                                  )->button( text = `Reject`
@@ -69,25 +69,25 @@ CLASS z2ui5_cl_demo_app_235 IMPLEMENTATION.
           )->label(
                                  )->bar(
                                      )->content_left(
-                                         )->label( text = `Bar cannot really handle overflow it just cuts the content.` )->get_parent(
+                                         )->label( `Bar cannot really handle overflow it just cuts the content.` )->get_parent(
                                      )->content_middle(
                                          )->button( text = `Accept`
                                                     type = `Accept`
-                                         )->label( text = `This is a long non-shrinkable label.`
+                                         )->label( `This is a long non-shrinkable label.`
                                          )->button( text = `Reject`
                                                     type = `Reject`
                                          )->button( text = `Edit`
                                          )->button( text = `Big Big Big Big Big Big Big Big Button` )->get_parent( )->get_parent(
           )->label(
                                  )->overflow_toolbar(
-                                     )->label( text = `OverflowToolbar provides a See more (...) button for overflow.`
+                                     )->label( `OverflowToolbar provides a See more (...) button for overflow.`
                                          )->layout_data(
                                              )->toolbar_layout_data( shrinkable = abap_false )->get_parent( )->get_parent(
                                      )->button( text = `Accept`
                                                 type = `Accept`
                                          )->layout_data(
                                              )->toolbar_layout_data( shrinkable = abap_true )->get_parent( )->get_parent(
-                                     )->label( text = `This is a long non-shrinkable label.`
+                                     )->label( `This is a long non-shrinkable label.`
                                          )->layout_data(
                                              )->toolbar_layout_data( shrinkable = abap_false )->get_parent( )->get_parent(
                                      )->button( text = `Reject`

--- a/src/z2ui5_cl_demo_app_236.clas.abap
+++ b/src/z2ui5_cl_demo_app_236.clas.abap
@@ -34,7 +34,7 @@ CLASS z2ui5_cl_demo_app_236 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout(
                           class = `sapUiContentPadding`
                           width = `100%`
-                          )->content( ns = `layout`
+                          )->content( `layout`
                               )->message_strip(
                                   showicon = abap_true
                                   text     = `This TextArea shows up to 7 lines, then a scrollbar is presented.`
@@ -88,7 +88,7 @@ CLASS z2ui5_cl_demo_app_236 IMPLEMENTATION.
                                   )->simple_form( "ns = `form`
                                       editable = `true`
                                       layout   = `ResponsiveGridLayout`
-                                      )->label( text = `Comment`
+                                      )->label( `Comment`
                               )->text_area( value                                                                                     = `Lorem ipsum dolor st amet, consetetur sadipscing elitr, sed diam nonumy ` &&
                                                     `eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
                                                     `At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, ` &&

--- a/src/z2ui5_cl_demo_app_239.clas.abap
+++ b/src/z2ui5_cl_demo_app_239.clas.abap
@@ -87,8 +87,8 @@ CLASS z2ui5_cl_demo_app_239 IMPLEMENTATION.
              layout     = `ResponsiveGridLayout`
              labelspanl = `4`
              labelspanm = `4`
-             )->content( ns = `form`
-                 )->label( text = `Clearing with Customer`
+             )->content( `form`
+                 )->label( `Clearing with Customer`
                  )->checkbox( text = `Option`
                  )->checkbox( text     = `Option 2`
                               selected = abap_true )->get(

--- a/src/z2ui5_cl_demo_app_240.clas.abap
+++ b/src/z2ui5_cl_demo_app_240.clas.abap
@@ -48,7 +48,7 @@ CLASS z2ui5_cl_demo_app_240 IMPLEMENTATION.
            href   = 'https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.Switch/sample/sap.m.sample.Switch' ).
 
     DATA(layout) = page->vbox(
-                            class = `sapUiSmallMargin`
+                            `sapUiSmallMargin`
                             )->hbox(
                                 )->switch( state = abap_true )->get(
                                     )->layout_data(

--- a/src/z2ui5_cl_demo_app_242.clas.abap
+++ b/src/z2ui5_cl_demo_app_242.clas.abap
@@ -51,8 +51,8 @@ CLASS z2ui5_cl_demo_app_242 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout(
                           class = `sapUiContentPadding`
                           width = `100%`
-                          )->content( ns = `layout`
-                              )->html( content = `<div class="content"><h4>Lorem ipsum</h4><div>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, ` &&
+                          )->content( `layout`
+                              )->html( `<div class="content"><h4>Lorem ipsum</h4><div>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, ` &&
                                                  `sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
                                                  `At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. ` &&
                                                  `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&

--- a/src/z2ui5_cl_demo_app_243.clas.abap
+++ b/src/z2ui5_cl_demo_app_243.clas.abap
@@ -33,7 +33,7 @@ CLASS z2ui5_cl_demo_app_243 IMPLEMENTATION.
                class      = `sapUiContentPadding`
              )->sub_header( )->toolbar( design = `Info`
                  )->icon( src = `sap-icon://begin`
-                     )->text( text = `This sample demonstrates classes which let you to add negative margin at two opposite sides (begin/end).` )->get_parent( )->get_parent( ).
+                     )->text( `This sample demonstrates classes which let you to add negative margin at two opposite sides (begin/end).` )->get_parent( )->get_parent( ).
 
     DATA(layout) = page->panel( class = `sapUiTinyNegativeMarginBeginEnd`
                           )->content(

--- a/src/z2ui5_cl_demo_app_248.clas.abap
+++ b/src/z2ui5_cl_demo_app_248.clas.abap
@@ -48,11 +48,11 @@ CLASS z2ui5_cl_demo_app_248 IMPLEMENTATION.
            href   = 'https://sapui5.hana.ondemand.com/sdk/#/entity/sap.ui.layout.Splitter/sample/sap.ui.layout.sample.Splitter3' ).
 
     DATA(layout) = page->splitter(
-                          )->text( text = `Content 1` )->get(
+                          )->text( `Content 1` )->get(
                               )->layout_data(
                                   )->splitter_layout_data( size      = `30%`
                                                            resizable = abap_false )->get_parent( )->get_parent( )->get_parent(
-                          )->text( text = `Content 2` )->get(
+                          )->text( `Content 2` )->get(
                               )->layout_data(
                                   )->splitter_layout_data( size = `auto` ).
 

--- a/src/z2ui5_cl_demo_app_253.clas.abap
+++ b/src/z2ui5_cl_demo_app_253.clas.abap
@@ -62,13 +62,13 @@ CLASS z2ui5_cl_demo_app_253 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout( class = `sapUiContentPadding equalColumns`
                                           width = `100%`
                           )->flex_box( class = `columns`
-                              )->text( text = `Although they have different amounts of text, both columns are of equal height.` )->get(
+                              )->text( `Although they have different amounts of text, both columns are of equal height.` )->get(
                                   )->layout_data(
                                       )->flex_item_data( growfactor       = `1`
                                                          basesize         = `0`
                                                          backgrounddesign = `Solid`
                                                          styleclass       = `sapUiTinyMargin` )->get_parent( )->get_parent(
-                              )->text( text = `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, ` &&
+                              )->text( `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, ` &&
                                               `sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. ` &&
                                               `At vero eos et accusam et justo hey nonny no duo dolores et ea rebum. ` &&
                                               `Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. ` &&

--- a/src/z2ui5_cl_demo_app_254.clas.abap
+++ b/src/z2ui5_cl_demo_app_254.clas.abap
@@ -83,35 +83,35 @@ CLASS z2ui5_cl_demo_app_254 IMPLEMENTATION.
                           fitcontainer = `abap_true`
                           alignitems   = `Stretch`
                           class        = `sapUiSmallMargin nestedFlexboxes`
-                          )->html( content = `<h2>1</h2>`
-                              )->layout_data( ns = `core`
+                          )->html( `<h2>1</h2>`
+                              )->layout_data( `core`
                                   )->flex_item_data( growfactor = `2`
                                                      styleclass = `item1` )->get_parent( )->get_parent(
-                          )->html( content = `<h2>2</h2>`
-                              )->layout_data( ns = `core`
+                          )->html( `<h2>2</h2>`
+                              )->layout_data( `core`
                                   )->flex_item_data( growfactor = `3`
                                                      styleclass = `item2` )->get_parent( )->get_parent(
       )->vbox( fitcontainer = abap_false
                               )->layout_data(
                                   )->flex_item_data( growfactor = `7` )->get_parent(
-      )->html( content = `<h2>3</h2>`
-                                  )->layout_data( ns = `core`
+      )->html( `<h2>3</h2>`
+                                  )->layout_data( `core`
                                       )->flex_item_data( growfactor = `5`
                                                          styleclass = `item3` )->get_parent( )->get_parent(
       )->hbox( fitcontainer = `abap_true`
                alignitems   = `Stretch`
                                   )->layout_data(
                                       )->flex_item_data( growfactor = `3` )->get_parent(
-      )->html( content = `<h2>4</h2>`
-                                          )->layout_data( ns = `core`
+      )->html( `<h2>4</h2>`
+                                          )->layout_data( `core`
                                               )->flex_item_data( growfactor = `1`
                                                                  styleclass = `item4` )->get_parent( )->get_parent(
-                                      )->html( content = `<h2>5</h2>`
-                                          )->layout_data( ns = `core`
+                                      )->html( `<h2>5</h2>`
+                                          )->layout_data( `core`
                                               )->flex_item_data( growfactor = `1`
                                                                  styleclass = `item5` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-      )->html( content = `<h2>6</h2>`
-                              )->layout_data( ns = `core`
+      )->html( `<h2>6</h2>`
+                              )->layout_data( `core`
                                   )->flex_item_data( growfactor = `5`
                                                      styleclass = `item6` )->get_parent( )->get_parent( ).
 

--- a/src/z2ui5_cl_demo_app_255.clas.abap
+++ b/src/z2ui5_cl_demo_app_255.clas.abap
@@ -93,32 +93,32 @@ CLASS z2ui5_cl_demo_app_255 IMPLEMENTATION.
            target = '_blank'
            href   = 'https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.FlexBox/sample/sap.m.sample.FlexBoxNav' ).
 
-    DATA(layout) = page->vbox( class = `navigationExamples`
+    DATA(layout) = page->vbox( `navigationExamples`
                           )->panel( headertext = `Variable width`
                               )->flex_box(
                                   class          = `ne-flexbox1`
                                   rendertype     = `List`
                                   justifycontent = `Center`
                                   alignitems     = `Center`
-                                  )->html( content = `<a >Item 1</a>` )->get_parent(
-                                  )->html( content = `<a >Long item 2</a>` )->get_parent(
-                                  )->html( content = `<a >Item 3</a>` )->get_parent( )->get_parent(
+                                  )->html( `<a >Item 1</a>` )->get_parent(
+                                  )->html( `<a >Long item 2</a>` )->get_parent(
+                                  )->html( `<a >Item 3</a>` )->get_parent( )->get_parent(
       )->panel( headertext = `Same width, transition effect`
                               )->flex_box(
                                   class          = `ne-flexbox2`
                                   rendertype     = `List`
                                   justifycontent = `SpaceBetween`
                                   alignitems     = `Center`
-                                  )->html( content = `<a >Item 1</a>` )->get(
-                                      )->layout_data( ns = `core`
+                                  )->html( `<a >Item 1</a>` )->get(
+                                      )->layout_data( `core`
                                           )->flex_item_data( growfactor = `1`
                                                              basesize   = `25%` )->get_parent( )->get_parent(
-                                  )->html( content = `<a >Long item 2</a>` )->get(
-                                      )->layout_data( ns = `core`
+                                  )->html( `<a >Long item 2</a>` )->get(
+                                      )->layout_data( `core`
                                           )->flex_item_data( growfactor = `1`
                                                              basesize   = `25%` )->get_parent( )->get_parent(
-                                  )->html( content = `<a >Item 3</a>` )->get(
-                                      )->layout_data( ns = `core`
+                                  )->html( `<a >Item 3</a>` )->get(
+                                      )->layout_data( `core`
                                           )->flex_item_data( growfactor = `1`
                                                              basesize   = `25%` )->get_parent( )->get_parent( ).
 

--- a/src/z2ui5_cl_demo_app_256.clas.abap
+++ b/src/z2ui5_cl_demo_app_256.clas.abap
@@ -65,30 +65,30 @@ CLASS z2ui5_cl_demo_app_256 IMPLEMENTATION.
     DATA(layout) = page->fix_flex( ns             = `layout`
                                    class          = `fixFlexFixedSize`
                                    fixcontentsize = `150px`
-                         )->fix_content( ns = `layout`
+                         )->fix_content( `layout`
                                 )->scroll_container( height   = `100%`
                                                      vertical = abap_true
-                                    )->text( text = `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
+                                    )->text( `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
                                                     `Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley `      &&
                                                     `of type and scrambled it to make a type specimen book. `                                                                   &&
                                                     `It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ` &&
                                                     `It was popularised in the 1960s with the release of Letraset sheets containing.`
-                                    )->text( text = `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
+                                    )->text( `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
                                                     `Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley `      &&
                                                     `of type and scrambled it to make a type specimen book. `                                                                   &&
                                                     `It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ` &&
                                                     `It was popularised in the 1960s with the release of Letraset sheets containing.`
-                                    )->text( text = `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
+                                    )->text( `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
                                                     `Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley `      &&
                                                     `of type and scrambled it to make a type specimen book. `                                                                   &&
                                                     `It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ` &&
                                                     `It was popularised in the 1960s with the release of Letraset sheets containing.`
-                                    )->text( text = `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
+                                    )->text( `Fix content - Lorem Ipsum is simply dummy text of the printing and typesetting industry. `                                 &&
                                                     `Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley `      &&
                                                     `of type and scrambled it to make a type specimen book. `                                                                   &&
                                                     `It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. ` &&
                                                     `It was popularised in the 1960s with the release of Letraset sheets containing.` )->get_parent( )->get_parent(
-                         )->flex_content( ns = `layout`
+                         )->flex_content( `layout`
                                     )->text( class = `column1`
                                              text  = `This container is flexible and it will adapt its size to fill the remaining size in the FixFlex control` ).
 

--- a/src/z2ui5_cl_demo_app_260.clas.abap
+++ b/src/z2ui5_cl_demo_app_260.clas.abap
@@ -50,17 +50,17 @@ CLASS z2ui5_cl_demo_app_260 IMPLEMENTATION.
     DATA(layout) = page->splitter( height      = `500px`
                                    orientation = `Vertical`
                           )->splitter( )->get(
-                              )->layout_data( ns = `layout`
+                              )->layout_data( `layout`
                                   )->splitter_layout_data( size = `50px` )->get_parent( )->get_parent(
-                              )->content_areas( ns = `layout`
+                              )->content_areas( `layout`
                                   )->button( width = `100%`
                                              text  = `Content 1` )->get(
                                       )->layout_data(
                                           )->splitter_layout_data( size = `auto` )->get_parent( )->get_parent( )->get_parent( )->get_parent( )->get_parent(
                           )->splitter( )->get(
-                              )->layout_data( ns = `layout`
+                              )->layout_data( `layout`
                                   )->splitter_layout_data( size = `auto` )->get_parent( )->get_parent(
-                              )->content_areas( ns = `layout`
+                              )->content_areas( `layout`
                                   )->button( width = `100%`
                                              text  = `Content 2` )->get(
                                        )->layout_data(
@@ -81,9 +81,9 @@ CLASS z2ui5_cl_demo_app_260 IMPLEMENTATION.
                                   )->splitter_layout_data( size    = `30%`
                                                            minsize = `200px` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
                           )->splitter( )->get(
-                               )->layout_data( ns = `layout`
+                               )->layout_data( `layout`
                                    )->splitter_layout_data( size = `50px` )->get_parent( )->get_parent( ")->get_parent(
-                               )->content_areas( ns = `layout`
+                               )->content_areas( `layout`
                                    )->button( width = `100%`
                                               text  = `Content 6` )->get(
                                        )->layout_data(

--- a/src/z2ui5_cl_demo_app_264.clas.abap
+++ b/src/z2ui5_cl_demo_app_264.clas.abap
@@ -60,7 +60,7 @@ CLASS z2ui5_cl_demo_app_264 IMPLEMENTATION.
 
     page->flex_box( items     = client->_bind( lt_a_data )
                     direction = `Column`
-              )->vbox( class = `sapUiTinyMargin`
+              )->vbox( `sapUiTinyMargin`
                   )->label( text     = '{LABEL}'
                             labelfor = `SI`
                   )->step_input(

--- a/src/z2ui5_cl_demo_app_268.clas.abap
+++ b/src/z2ui5_cl_demo_app_268.clas.abap
@@ -91,32 +91,32 @@ CLASS z2ui5_cl_demo_app_268 IMPLEMENTATION.
                src   = `sap-icon://syringe`
                class = `size1`
                color = `#031E48` )->get(
-               )->layout_data( ns = `core`
+               )->layout_data( `core`
                    )->flex_item_data( growfactor = `1` )->get_parent( )->get_parent(
            )->icon(
                src   = `sap-icon://pharmacy`
                class = `size2`
                color = `#64E4CE` )->get(
-               )->layout_data( ns = `core`
+               )->layout_data( `core`
                    )->flex_item_data( growfactor = `1` )->get_parent( )->get_parent(
            )->icon(
                src   = `sap-icon://electrocardiogram`
                class = `size3`
                color = `#E69A17` )->get(
-               )->layout_data( ns = `core`
+               )->layout_data( `core`
                    )->flex_item_data( growfactor = `1` )->get_parent( )->get_parent(
            )->icon(
                src   = `sap-icon://doctor`
                class = `size4`
                color = `#1C4C98` )->get(
-               )->layout_data( ns = `core`
+               )->layout_data( `core`
                    )->flex_item_data( growfactor = `1` )->get_parent( )->get_parent(
            )->icon(
                src   = `sap-icon://stethoscope`
                class = `size5`
                color = `#8875E7`
                press = client->_event( `handleStethoscopePress` ) )->get(
-               )->layout_data( ns = `core`
+               )->layout_data( `core`
                    )->flex_item_data( growfactor = `1` ).
 
     client->view_display( page->stringify( ) ).

--- a/src/z2ui5_cl_demo_app_269.clas.abap
+++ b/src/z2ui5_cl_demo_app_269.clas.abap
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_demo_app_269 IMPLEMENTATION.
         navbuttonpressed    = client->_event_nav_app_leave( )
         )->_generic( name = `menu`
                      ns   = `f`
-            )->_generic( name = `Menu`
+            )->_generic( `Menu`
                 )->menu_item( text = `Flight booking`
                               icon = `sap-icon://flight`
                 )->menu_item( text = `Car rental`

--- a/src/z2ui5_cl_demo_app_273.clas.abap
+++ b/src/z2ui5_cl_demo_app_273.clas.abap
@@ -70,9 +70,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Beamer`
                                      title    = `This is a beamer`
                                      subtitle = `This is beamer's description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Beamer`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Beamer`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -91,9 +91,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `USB`
                                      title    = `This is a USB`
                                      subtitle = `This is USB's description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `USB`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `USB`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -112,9 +112,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Speakers`
                                      title    = `These are speakers`
                                      subtitle = `This is speakers' description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Speakers`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Speakers`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -133,9 +133,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Nature image`
                                      title    = `This is a sample image`
                                      subtitle = `This is a place for description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Nature image`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Nature image`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -154,9 +154,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Nature image`
                                      title    = `This is a sample image`
                                      subtitle = `This is a place for description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Nature image`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Nature image`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -175,9 +175,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Nature image`
                                      title    = `This is a sample image`
                                      subtitle = `This is a place for description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Nature image`
-                                  )->text( text = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Nature image`
+                                  )->text( `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam interdum lectus et tempus blandit.`    &&
                                                   `Sed porta ex quis tortor gravida, ut suscipit felis dignissim. Ut iaculis elit vel ligula scelerisque,` &&
                                                   `et porttitor est pretium. Suspendisse purus dolor, fermentum in tortor eu, semper finibus velit.`       &&
                                                   `Proin vel lobortis leo, vel eleifend lorem. Etiam ac erat sollicitudin, condimentum magna ac,`          &&
@@ -196,9 +196,9 @@ CLASS z2ui5_cl_demo_app_273 IMPLEMENTATION.
                                      alt      = `Nature image`
                                      title    = `This is a sample image`
                                      subtitle = `This is a place for description` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
-                          )->vbox( class = `sapUiSmallMarginBegin`
-                              )->title( text = `Unavailable image`
-                                  )->text( text = `Shows an error when an image could not be loaded, or when it takes too much time to load it.` )->get_parent( )->get_parent( ).
+                          )->vbox( `sapUiSmallMarginBegin`
+                              )->title( `Unavailable image`
+                                  )->text( `Shows an error when an image could not be loaded, or when it takes too much time to load it.` )->get_parent( )->get_parent( ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_279.clas.abap
+++ b/src/z2ui5_cl_demo_app_279.clas.abap
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_demo_app_279 IMPLEMENTATION.
       class   = `sapUiSmallMarginBegin`
       visible = client->_bind( dirty ) ).
 
-    page->_z2ui5( )->focus( focusid = `input` ).
+    page->_z2ui5( )->focus( `input` ).
 
 
     page->_z2ui5( )->dirty( client->_bind( dirty ) ).

--- a/src/z2ui5_cl_demo_app_282.clas.abap
+++ b/src/z2ui5_cl_demo_app_282.clas.abap
@@ -58,7 +58,7 @@ CLASS z2ui5_cl_demo_app_282 IMPLEMENTATION.
                                       )->button( type  = `Back`
                                                  press = client->_event( val = `onPress` t_arg = VALUE #( ( `${$source>/id}` ) ) )
                                       )->toolbar_spacer(
-                                      )->title( text = `Title`
+                                      )->title( `Title`
                                       )->toolbar_spacer(
                                       )->button( icon           = `sap-icon://edit`
                                                  press          = client->_event( val = `onPress` t_arg = VALUE #( ( `${$source>/id}` ) ) )

--- a/src/z2ui5_cl_demo_app_284.clas.abap
+++ b/src/z2ui5_cl_demo_app_284.clas.abap
@@ -65,35 +65,35 @@ CLASS z2ui5_cl_demo_app_284 IMPLEMENTATION.
                                           emptyspanm     = `0`
                                           columnsl       = `2`
                                           columnsm       = `2`
-                                          )->content( ns = `form`
+                                          )->content( `form`
                                               )->title( ns   = `core`
                                                         text = `Office`
-                                              )->label( text = `Name`
-                                              )->text( text = `Red Point Stores`
-                                              )->label( text = `Street/No.`
-                                              )->text( text = `Main St 1618`
-                                              )->label( text = `ZIP Code/City`
-                                              )->text( text = `31415 Maintown`
-                                              )->label( text = `Country`
-                                              )->text( text = `Germany`
+                                              )->label( `Name`
+                                              )->text( `Red Point Stores`
+                                              )->label( `Street/No.`
+                                              )->text( `Main St 1618`
+                                              )->label( `ZIP Code/City`
+                                              )->text( `31415 Maintown`
+                                              )->label( `Country`
+                                              )->text( `Germany`
                                               )->title( ns   = `core`
                                                         text = `Online`
-                                              )->label( text = `Web`
-                                              )->text( text = `http://www.sap.com`
-                                              )->label( text = `Twitter`
-                                              )->text( text = `@sap` )->get_parent(
-                                          )->layout_data( ns = `form`
+                                              )->label( `Web`
+                                              )->text( `http://www.sap.com`
+                                              )->label( `Twitter`
+                                              )->text( `@sap` )->get_parent(
+                                          )->layout_data( `form`
                                               )->flex_item_data( shrinkfactor     = `0`
                                                                  backgrounddesign = `Solid`
                                                                  styleclass       = `sapContrastPlus` )->get_parent( )->get_parent(
                                       )->analytical_table( ns            = `table`
                                                            selectionmode = `MultiToggle`
-                                          )->rowmode( ns = `table`
+                                          )->rowmode( `table`
                                               )->auto( ns               = `trm`
                                                        rowcontentheight = `32` )->get_parent( )->get_parent(
                                           )->toolbar( ns = `table`
                                             )->overflow_toolbar(
-                                              )->title( text = `Title Bar Here`
+                                              )->title( `Title Bar Here`
                                               )->toolbar_spacer(
                                               )->search_field( width = `12rem`
                                               )->segmented_button(
@@ -104,11 +104,11 @@ CLASS z2ui5_cl_demo_app_284 IMPLEMENTATION.
                                                          type = `Transparent`
                                               )->button( icon = `sap-icon://action-settings`
                                                          type = `Transparent` )->get_parent( )->get_parent(
-                                          )->columns( ns = `table`
-                                              )->analytical_column( ns = `table` )->get_parent(
-                                              )->analytical_column( ns = `table` )->get_parent(
-                                              )->analytical_column( ns = `table` )->get_parent( )->get_parent(
-                                          )->layout_data( ns = `table`
+                                          )->columns( `table`
+                                              )->analytical_column( `table` )->get_parent(
+                                              )->analytical_column( `table` )->get_parent(
+                                              )->analytical_column( `table` )->get_parent( )->get_parent(
+                                          )->layout_data( `table`
                                               )->flex_item_data( growfactor = `1`
                                                                  basesize   = `0%`
                                                                  styleclass = `sapUiResponsiveContentPadding` )->get_parent( )->get_parent( )->get_parent( )->get_parent(

--- a/src/z2ui5_cl_demo_app_285.clas.abap
+++ b/src/z2ui5_cl_demo_app_285.clas.abap
@@ -65,24 +65,24 @@ CLASS z2ui5_cl_demo_app_285 IMPLEMENTATION.
                                  emptyspanm     = `0`
                                  columnsl       = `2`
                                  columnsm       = `2`
-                                 )->content( ns = `form`
+                                 )->content( `form`
                                      )->title( ns   = `core`
                                                text = `Office`
-                                     )->label( text = `Name`
-                                     )->text( text = `Red Point Stores`
-                                     )->label( text = `Street/No.`
-                                     )->text( text = `Main St 1618`
-                                     )->label( text = `ZIP Code/City`
-                                     )->text( text = `31415 Maintown`
-                                     )->label( text = `Country`
-                                     )->text( text = `Germany`
+                                     )->label( `Name`
+                                     )->text( `Red Point Stores`
+                                     )->label( `Street/No.`
+                                     )->text( `Main St 1618`
+                                     )->label( `ZIP Code/City`
+                                     )->text( `31415 Maintown`
+                                     )->label( `Country`
+                                     )->text( `Germany`
                                      )->title( ns   = `core`
                                                text = `Online`
-                                     )->label( text = `Web`
-                                     )->text( text = `http://www.sap.com`
-                                     )->label( text = `Twitter`
-                                     )->text( text = `@sap` )->get_parent(
-                                 )->layout_data( ns = `form`
+                                     )->label( `Web`
+                                     )->text( `http://www.sap.com`
+                                     )->label( `Twitter`
+                                     )->text( `@sap` )->get_parent(
+                                 )->layout_data( `form`
                                      )->flex_item_data( shrinkfactor     = `0`
                                                         backgrounddesign = `Solid`
                                                         styleclass       = `sapContrastPlus` )->get_parent( )->get_parent(
@@ -99,7 +99,7 @@ CLASS z2ui5_cl_demo_app_285 IMPLEMENTATION.
                                  )->content(
                                      )->analytical_table( ns            = `table`
                                                           selectionmode = `MultiToggle`
-                                         )->rowmode( ns = `table`
+                                         )->rowmode( `table`
                                              )->auto( ns               = `trm`
                                                       rowcontentheight = `32` )->get_parent( )->get_parent(
                                          )->toolbar( ns = `table`
@@ -116,11 +116,11 @@ CLASS z2ui5_cl_demo_app_285 IMPLEMENTATION.
                                                             type = `Transparent`
                                                  )->button( icon = `sap-icon://action-settings`
                                                             type = `Transparent` )->get_parent( )->get_parent(
-                                         )->columns( ns = `table`
-                                             )->analytical_column( ns = `table` )->get_parent(
-                                             )->analytical_column( ns = `table` )->get_parent(
-                                             )->analytical_column( ns = `table` )->get_parent(
-                                             )->analytical_column( ns = `table` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
+                                         )->columns( `table`
+                                             )->analytical_column( `table` )->get_parent(
+                                             )->analytical_column( `table` )->get_parent(
+                                             )->analytical_column( `table` )->get_parent(
+                                             )->analytical_column( `table` )->get_parent( )->get_parent( )->get_parent( )->get_parent(
                                  )->layout_data(
                                      )->flex_item_data( growfactor = `1`
                                                         basesize   = `0%` )->get_parent( )->get_parent( )->get_parent( )->get_parent(

--- a/src/z2ui5_cl_demo_app_289.clas.abap
+++ b/src/z2ui5_cl_demo_app_289.clas.abap
@@ -62,13 +62,13 @@ CLASS z2ui5_cl_demo_app_289 IMPLEMENTATION.
            items    = client->_bind( lt_a_data )
            )->columns(
                )->column(
-                   )->text( text = `Products`
+                   )->text( `Products`
                )->get_parent(
                )->column(
-                   )->text( text = `Status`
+                   )->text( `Status`
                )->get_parent(
                )->column(
-                   )->text( text = `Status (active)`
+                   )->text( `Status (active)`
                )->get_parent( )->get_parent(
            )->column_list_item(
                )->object_identifier(

--- a/src/z2ui5_cl_demo_app_291.clas.abap
+++ b/src/z2ui5_cl_demo_app_291.clas.abap
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_demo_app_291 IMPLEMENTATION.
     page->vertical_layout(
            class = `sapUiContentPadding`
            width = `100%`
-           )->content( ns = `layout`
+           )->content( `layout`
       )->message_strip(
                   text                = client->_bind( lv_default )
                   enableformattedtext = abap_true

--- a/src/z2ui5_cl_demo_app_292.clas.abap
+++ b/src/z2ui5_cl_demo_app_292.clas.abap
@@ -53,7 +53,7 @@ CLASS Z2UI5_CL_DEMO_APP_292 IMPLEMENTATION.
     page->vertical_layout(
             class = `sapUiContentPadding`
             width = `100%`
-           )->title( text = `Breadcrumbs with current page aggregation set`
+           )->title( `Breadcrumbs with current page aggregation set`
            )->breadcrumbs( id                  = `idBreadcrumbs`
                            separatorstyle      = `{/selected}`
                            currentlocationtext = `Page 7`

--- a/src/z2ui5_cl_demo_app_293.clas.abap
+++ b/src/z2ui5_cl_demo_app_293.clas.abap
@@ -53,7 +53,7 @@ CLASS z2ui5_cl_demo_app_293 IMPLEMENTATION.
     page->vertical_layout(
             class = `sapUiContentPadding`
             width = `100%`
-            )->content( ns = `layout`
+            )->content( `layout`
                 )->link(
                     text  = `Open message box`
                     press = client->_event( `handleLinkPress` )
@@ -69,7 +69,7 @@ CLASS z2ui5_cl_demo_app_293 IMPLEMENTATION.
     page->vertical_layout(
            class = `sapUiContentPadding`
            width = `100%`
-           )->content( ns = `layout`
+           )->content( `layout`
                )->label( text     = `Links with Icons`
                          design   = `Bold`
                          wrapping = abap_true

--- a/src/z2ui5_cl_demo_app_294.clas.abap
+++ b/src/z2ui5_cl_demo_app_294.clas.abap
@@ -62,7 +62,7 @@ CLASS z2ui5_cl_demo_app_294 IMPLEMENTATION.
 
     page->flex_box( items     = client->_bind( lt_a_data )
                     direction = `Column`
-             )->vbox( class = `sapUiTinyMargin`
+             )->vbox( `sapUiTinyMargin`
                  )->label( text     = '{LABEL}'
                            labelfor = `SI`
                  )->date_picker(

--- a/src/z2ui5_cl_demo_app_295.clas.abap
+++ b/src/z2ui5_cl_demo_app_295.clas.abap
@@ -62,8 +62,8 @@ CLASS z2ui5_cl_demo_app_295 IMPLEMENTATION.
 
     page->flex_box( items     = client->_bind( lt_a_data )
                     direction = `Column`
-             )->vbox( class = `sapUiTinyMargin`
-                 )->label( text = '{LABEL}'
+             )->vbox( `sapUiTinyMargin`
+                 )->label( '{LABEL}'
                  )->date_range_selection(
                      width          = `100%`
                      valuestate     = '{VALUE_STATE}'

--- a/src/z2ui5_cl_demo_app_296.clas.abap
+++ b/src/z2ui5_cl_demo_app_296.clas.abap
@@ -59,8 +59,8 @@ CLASS z2ui5_cl_demo_app_296 IMPLEMENTATION.
                                id   = `idSearchListToolbar`
                   )->get_parent(
               )->get_parent(
-              )->vbox( class = `sapUiSmallMargin`
-                  )->label( text = `Default Search Field:`
+              )->vbox( `sapUiSmallMargin`
+                  )->label( `Default Search Field:`
                   )->search_field( width = `90%`
                                    class = `sapUiSmallMargin`
               )->get_parent( ).

--- a/src/z2ui5_cl_demo_app_300.clas.abap
+++ b/src/z2ui5_cl_demo_app_300.clas.abap
@@ -360,9 +360,9 @@ CLASS z2ui5_cl_demo_app_300 IMPLEMENTATION.
               )->table(
                   )->columns(
                       )->column(
-                          )->text( text = `ObjectStatus with default text wrapping` )->get_parent(
+                          )->text( `ObjectStatus with default text wrapping` )->get_parent(
                       )->column(
-                          )->text( text = `ObjectStatus with enhanced text wrapping via 'sapMObjectStatusLongText' CSS class` )->get_parent(
+                          )->text( `ObjectStatus with enhanced text wrapping via 'sapMObjectStatusLongText' CSS class` )->get_parent(
                       )->get_parent(
                   )->column_list_item(
                       )->cells(

--- a/src/z2ui5_cl_demo_app_301.clas.abap
+++ b/src/z2ui5_cl_demo_app_301.clas.abap
@@ -65,27 +65,27 @@ CLASS z2ui5_cl_demo_app_301 IMPLEMENTATION.
                  autopopinmode = abap_true
                )->columns(
                    )->column(
-                       )->text( text = `Product`
+                       )->text( `Product`
                    )->get_parent(
                    )->column(
-                       )->text( text = `Attribute 1`
+                       )->text( `Attribute 1`
                    )->get_parent(
                    )->column(
-                       )->text( text = `Attribute 2`
+                       )->text( `Attribute 2`
                    )->get_parent(
                    )->column(
-                       )->text( text = `Status`
+                       )->text( `Status`
                    )->get_parent(
                )->get_parent(
       )->items(
                    )->column_list_item(
                        )->cells(
-                           )->text( text = `{NAME}` ")->get_parent(
+                           )->text( `{NAME}` ")->get_parent(
                            )->expandable_text( class        = `sapUiTinyMarginBottom sapUiTinyMarginTop`
                                                text         = `{ATTRIBUTE_1}`
                                                overflowmode = `{OVERFLOW_MODE}` )->get_parent(
-                           )->text( text = `{ATTRIBUTE_2}` )->get_parent(
-                           )->text( text = `{STATUS}` )->get_parent(
+                           )->text( `{ATTRIBUTE_2}` )->get_parent(
+                           )->text( `{STATUS}` )->get_parent(
                        )->get_parent(
                    )->get_parent(
                )->get_parent( ).

--- a/src/z2ui5_cl_demo_app_302.clas.abap
+++ b/src/z2ui5_cl_demo_app_302.clas.abap
@@ -62,13 +62,13 @@ CLASS z2ui5_cl_demo_app_302 IMPLEMENTATION.
            items    = client->_bind( lt_a_data )
            )->columns(
                )->column(
-                   )->text( text = `Products`
+                   )->text( `Products`
                )->get_parent(
                )->column(
-                   )->text( text = `Supplier`
+                   )->text( `Supplier`
                )->get_parent(
                )->column(
-                   )->text( text = `Supplier (active)`
+                   )->text( `Supplier (active)`
                )->get_parent( )->get_parent(
            )->column_list_item(
                )->object_identifier(

--- a/src/z2ui5_cl_demo_app_303.clas.abap
+++ b/src/z2ui5_cl_demo_app_303.clas.abap
@@ -28,13 +28,13 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
             )->vbox(
                 )->title( text     = `Object Page Header with Header Container`
                           wrapping = abap_true
-                )->label( text = `Example of an ObjectPage with header facet` ).
+                )->label( `Example of an ObjectPage with header facet` ).
 
-    header_title->expanded_content( ns = `uxap`
-        )->label( text = `Example of an ObjectPage with header facet` ).
+    header_title->expanded_content( `uxap`
+        )->label( `Example of an ObjectPage with header facet` ).
 
     header_title->snapped_title_on_mobile(
-        )->title( text = `Object Page Header with Header Container` ).
+        )->title( `Object Page Header with Header Container` ).
 
     header_title->actions( 'uxap'
         )->button( text = `Edit`
@@ -46,7 +46,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     text    = `Share`
                                     tooltip = `action` ).
 
-    DATA(header_content) = object_page_layout->header_content( ns = 'uxap'
+    DATA(header_content) = object_page_layout->header_content( 'uxap'
         )->header_container_control( id           = `headerContainer`
                                      scrollstep   = `200`
                                      showdividers = abap_false ).
@@ -55,7 +55,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
         )->avatar( src         = `https://sapui5.hana.ondemand.com/test-resources/sap/uxap/images/imageID_275314.png`
                    class       = `sapUiMediumMarginEnd sapUiSmallMarginBottom`
                    displaysize = `L`
-        )->vbox( class = `sapUiSmallMarginBottom`
+        )->vbox( `sapUiSmallMarginBottom`
             )->title( class = `sapUiTinyMarginBottom` )->get(
                 )->link( text = `Order Details`
                 )->get_parent(
@@ -63,23 +63,23 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                      rendertype = `Bare`
                 )->label( text  = `Manufacturer:`
                           class = `sapUiTinyMarginEnd`
-                )->text( text = `Robotech`
+                )->text( `Robotech`
                 )->get_parent(
             )->hbox( class      = `sapUiTinyMarginBottom`
                      rendertype = `Bare`
                 )->label( text  = `Factory:`
                           class = `sapUiTinyMarginEnd`
-                )->text( text = `Florida, OL`
+                )->text( `Florida, OL`
                 )->get_parent(
             )->hbox( class      = `sapUiTinyMarginBottom`
                      rendertype = `Bare`
                 )->label( text  = `Supplier:`
                           class = `sapUiTinyMarginEnd`
-                )->text( text = `Robotech (234242343)`
+                )->text( `Robotech (234242343)`
                 )->get_parent(
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( text  = `Contact Information`
                   class = `sapUiTinyMarginBottom`
         )->hbox( class = `sapUiTinyMarginBottom`
@@ -98,7 +98,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                      class = `sapUiSmallMarginBegin`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->hbox( class = `sapUiTinyMarginBottom`
             )->label( text  = `Created By:`
                       class = `sapUiSmallMarginEnd`
@@ -108,7 +108,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                  rendertype = `Bare`
             )->label( text  = `Created On:`
                       class = `sapUiSmallMarginEnd`
-            )->text( text = `February 20, 2020`
+            )->text( `February 20, 2020`
             )->get_parent(
         )->hbox( class = `sapUiTinyMarginBottom`
             )->label( text  = `Changed By:`
@@ -118,10 +118,10 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
         )->hbox( class = `sapUiTinyMarginBottom`
             )->label( text  = `Changed On:`
                       class = `sapUiSmallMarginEnd`
-            )->text( text = `February 20, 2020`
+            )->text( `February 20, 2020`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( text  = `Product Description`
                   class = `sapUiTinyMarginBottom`
         )->text(
@@ -129,7 +129,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
             text  = |Top-design high-quality coffee mug - ideal for a comforting moment; Pack: 6; material: | &&
             |Porcelain - durable dishwasher and microwave-safe porcelain that cleans easily and is ideal for everyday service. Comes in two bright colors.|
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( class = `sapUiTinyMarginBottom` )->get(
             )->link( text = `Status`
             )->get_parent(
@@ -138,7 +138,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                           class = `sapMObjectStatusLarge`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( text  = `Delivery Time`
                   class = `sapUiTinyMarginBottom`
         )->object_status( text  = `12 Days`
@@ -146,7 +146,7 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                           class = `sapMObjectStatusLarge`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( text  = `Assembly Option`
                   class = `sapUiTinyMarginBottom`
         )->object_status( text  = `To Be Selected`
@@ -154,23 +154,23 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                           class = `sapMObjectStatusLarge`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( text  = `Price`
                   class = `sapUiTinyMarginBottom`
         )->object_status( text  = `579 EUR`
                           class = `sapMObjectStatusLarge`
             )->get_parent(
         )->get_parent(
-      )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+      )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
         )->title( class = `sapUiTinyMarginBottom` )->get(
             )->link( text = `Average User Rating`
             )->get_parent(
-        )->label( text = `6 Reviews`
+        )->label( `6 Reviews`
         )->rating_indicator( value    = `4`
                              iconsize = `16px`
                              )->get_parent(
         )->vbox( alignitems = `End`
-            )->text( text = `4.1 out of 5` ).
+            )->text( `4.1 out of 5` ).
 
     DATA(section) = object_page_layout->sections( ).
 
@@ -188,12 +188,12 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     columnsl   = `3`
                                     columnsxl  = `4`
                                     labelspanl = `12`
-                        )->label( text = `Evangelize the UI framework across the company`
-                        )->text( text = `4 days overdue Cascaded`
-                        )->label( text = `Get trained in development management direction`
-                        )->text( text = `Due Nov 21`
-                        )->label( text = `Mentor junior developers`
-                        )->text( text = `Due Dec 31 Cascaded` ).
+                        )->label( `Evangelize the UI framework across the company`
+                        )->text( `4 days overdue Cascaded`
+                        )->label( `Get trained in development management direction`
+                        )->text( `Due Nov 21`
+                        )->label( `Mentor junior developers`
+                        )->text( `Due Dec 31 Cascaded` ).
     section->object_page_section( titleuppercase = abap_false
                                   id             = `personalSection`
                                   title          = `Personal`
@@ -212,10 +212,10 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanl = `12`
                         )->title( ns   = `core`
                                   text = `Phone Numbers`
-                            )->label( text = `Home`
-                            )->text( text = `+ 1 415-321-1234`
-                            )->label( text = `Office phone`
-                            )->text( text = `+ 1 415-321-5555`
+                            )->label( `Home`
+                            )->text( `+ 1 415-321-1234`
+                            )->label( `Office phone`
+                            )->text( `+ 1 415-321-5555`
                         )->get_parent(
                     )->simple_form( editable   = abap_false
                                     layout     = `ColumnLayout`
@@ -226,10 +226,10 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanl = `12`
                         )->title( ns   = `core`
                                   text = `Social Accounts`
-                            )->label( text = `LinkedIn`
-                            )->text( text = `/DeniseSmith`
-                            )->label( text = `Twitter`
-                            )->text( text = `@DeniseSmith`
+                            )->label( `LinkedIn`
+                            )->text( `/DeniseSmith`
+                            )->label( `Twitter`
+                            )->text( `@DeniseSmith`
                         )->get_parent(
                     )->simple_form( editable   = abap_false
                                     layout     = `ColumnLayout`
@@ -240,10 +240,10 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanl = `12`
                         )->title( ns   = `core`
                                   text = `Addresses`
-                            )->label( text = `Home Address`
-                            )->text( text = `2096 Mission Street`
-                            )->label( text = `Mailing Address`
-                            )->text( text = `PO Box 32114`
+                            )->label( `Home Address`
+                            )->text( `2096 Mission Street`
+                            )->label( `Mailing Address`
+                            )->text( `PO Box 32114`
                         )->get_parent(
                     )->simple_form( editable   = abap_false
                                     layout     = `ColumnLayout`
@@ -254,8 +254,8 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanl = `12`
                         )->title( ns   = `core`
                                   text = `Mailing Address`
-                            )->label( text = `Work`
-                            )->text( text = `DeniseSmith@sap.com`
+                            )->label( `Work`
+                            )->text( `DeniseSmith@sap.com`
                         )->get_parent(
                     )->get_parent(
                 )->get_parent(
@@ -275,8 +275,8 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanxl = `12`
                         )->title( ns   = `core`
                                   text = `Main Payment Method`
-                        )->label( text = `Bank Transfer`
-                        )->text( text = `Sparkasse Heimfeld, Germany`
+                        )->label( `Bank Transfer`
+                        )->text( `Sparkasse Heimfeld, Germany`
                         )->get_parent(
                     )->get_parent(
                 )->more_blocks(
@@ -292,8 +292,8 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanxl = `12`
                         )->title( ns   = `core`
                                   text = `Payment method for Expenses`
-                        )->label( text = `Extra Travel Expenses`
-                        )->text( text = `Cash 100 USD` ).
+                        )->label( `Extra Travel Expenses`
+                        )->text( `Cash 100 USD` ).
 
     section->object_page_section( titleuppercase = abap_false
                                   id             = `employmentSection`
@@ -314,12 +314,12 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanm  = `12`
                                     labelspanl  = `12`
                                     labelspanxl = `12`
-                        )->label( text = `Job classification`
-                        )->text( text = `Senior Ui Developer (UIDEV-SR)`
-                        )->label( text = `Pay Grade`
-                        )->text( text = `Salary Grade 18 (GR-14)`
-                        )->label( text = `Job title`
-                        )->text( text = `Developer`
+                        )->label( `Job classification`
+                        )->text( `Senior Ui Developer (UIDEV-SR)`
+                        )->label( `Pay Grade`
+                        )->text( `Salary Grade 18 (GR-14)`
+                        )->label( `Job title`
+                        )->text( `Developer`
                         )->get_parent(
                     )->simple_form( id          = `jobinfopart2`
                                     editable    = abap_false
@@ -332,19 +332,19 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanm  = `12`
                                     labelspanl  = `12`
                                     labelspanxl = `12`
-                        )->label( text = `Employee Class`
-                        )->text( text = `Employee`
-                        )->label( text = `FTE`
-                        )->text( text = `1`
+                        )->label( `Employee Class`
+                        )->text( `Employee`
+                        )->label( `FTE`
+                        )->text( `1`
                         )->get_parent(
                     )->horizontal_layout( class = `sapUiSmallMarginTop`
                         )->vertical_layout(
-                            )->label( text = `Manager`
+                            )->label( `Manager`
                                 )->horizontal_layout(
-                                    )->content( ns = `layout`
+                                    )->content( `layout`
                                     )->vertical_layout(
-                                        )->text( text = `James Smith`
-                                        )->text( text = `Development Manager`
+                                        )->text( `James Smith`
+                                        )->text( `Development Manager`
                                         )->get_parent(
                                     )->get_parent(
                                 )->get_parent(
@@ -367,10 +367,10 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                     labelspanl = `12`
                         )->title( ns   = `core`
                                   text = `Termination information`
-                            )->label( text = `Ok to return`
-                            )->text( text = `No`
-                            )->label( text = `Regret Termination`
-                            )->text( text = `Yes`
+                            )->label( `Ok to return`
+                            )->text( `No`
+                            )->label( `Regret Termination`
+                            )->text( `Yes`
                         )->get_parent(
                     )->get_parent(
                 )->more_blocks(
@@ -383,14 +383,14 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                         columnsxl  = `4`
                                         labelspans = `12`
                                         labelspanl = `12`
-                            )->label( text = `Start Date`
-                            )->text( text = `Jan 01, 2001`
-                            )->label( text = `End Date`
-                            )->text( text = `Jun 30, 2014`
-                            )->label( text = `Last Date Worked`
-                            )->text( text = `Jun 01, 2014`
-                            )->label( text = `Payroll End Date`
-                            )->text( text = `Jun 01, 2014`
+                            )->label( `Start Date`
+                            )->text( `Jan 01, 2001`
+                            )->label( `End Date`
+                            )->text( `Jun 30, 2014`
+                            )->label( `Last Date Worked`
+                            )->text( `Jun 01, 2014`
+                            )->label( `Payroll End Date`
+                            )->text( `Jun 01, 2014`
                             )->get_parent(
                         )->simple_form( id         = `empdetailpart3`
                                         editable   = abap_false
@@ -401,14 +401,14 @@ CLASS z2ui5_cl_demo_app_303 IMPLEMENTATION.
                                         columnsxl  = `4`
                                         labelspans = `12`
                                         labelspanl = `12`
-                            )->label( text = `Payroll End Date`
-                            )->text( text = `Jan 01, 2014`
-                            )->label( text = `Benefits End Date`
-                            )->text( text = `Jun 30, 2014`
-                            )->label( text = `Stock End Date`
-                            )->text( text = `Jun 01, 2014`
-                            )->label( text = `Eligible for Salary Contribution`
-                            )->text( text = `No` ).
+                            )->label( `Payroll End Date`
+                            )->text( `Jan 01, 2014`
+                            )->label( `Benefits End Date`
+                            )->text( `Jun 30, 2014`
+                            )->label( `Stock End Date`
+                            )->text( `Jun 01, 2014`
+                            )->label( `Eligible for Salary Contribution`
+                            )->text( `No` ).
 
     client->view_display( view->stringify( ) ).
   ENDMETHOD.

--- a/src/z2ui5_cl_demo_app_305.clas.abap
+++ b/src/z2ui5_cl_demo_app_305.clas.abap
@@ -74,7 +74,7 @@ CLASS z2ui5_cl_demo_app_305 IMPLEMENTATION.
 
     tab->items( )->column_list_item(
       )->cells(
-        )->text( text = '{TITLE}'
+        )->text( '{TITLE}'
           )->get(
             )->custom_data(
               )->core_custom_data( key        = 'color'

--- a/src/z2ui5_cl_demo_app_306.clas.abap
+++ b/src/z2ui5_cl_demo_app_306.clas.abap
@@ -58,7 +58,7 @@ CLASS z2ui5_cl_demo_app_306 IMPLEMENTATION.
                    navbuttonpress  = client->_event_nav_app_leave( )
                    shownavbutton   = client->check_app_prev_stack( ) ).
 
-    page->vbox( class = `sapUiSmallMargin`
+    page->vbox( `sapUiSmallMargin`
        )->label( text     = `facingMode: `
                  labelfor = `ComboFacingMode`
        )->combobox( id          = `ComboFacingMode`
@@ -67,7 +67,7 @@ CLASS z2ui5_cl_demo_app_306 IMPLEMENTATION.
        )->get( )->item( key  = `{KEY}`
                         text = `{TEXT}` ).
 
-    page->vbox( class = `sapUiSmallMargin`
+    page->vbox( `sapUiSmallMargin`
        )->label( text     = `device: `
                  labelfor = `ComboDevice`
        )->_z2ui5( )->camera_selector(

--- a/src/z2ui5_cl_demo_app_307.clas.abap
+++ b/src/z2ui5_cl_demo_app_307.clas.abap
@@ -191,14 +191,14 @@ CLASS z2ui5_cl_demo_app_307 IMPLEMENTATION.
                  backgrounddesign = `Transparent`
         )->header_toolbar(
             )->toolbar( height = `3rem`
-                )->title( text = `Grid List with Drag and Drop`
+                )->title( `Grid List with Drag and Drop`
             )->get_parent(
         )->get_parent(
         )->grid_list( id         = `gridList`
                       headertext = `GridList header`
                       items      = client->_bind_edit( items )
             )->drag_drop_config(
-                )->drag_info( sourceaggregation = `items`
+                )->drag_info( `items`
                 )->grid_drop_info(
                     targetaggregation = `items`
                     dropposition      = `Between`
@@ -210,7 +210,7 @@ CLASS z2ui5_cl_demo_app_307 IMPLEMENTATION.
                             ( `${$parameters>/droppedControl/oParent}.indexOfItem(${$parameters>/droppedControl})` )
                             ( `${$parameters>/dropPosition}` ) ) )
             )->get_parent(
-            )->custom_layout( ns = 'f'
+            )->custom_layout( 'f'
                 )->grid_box_layout( boxminwidth = `17rem`
             )->get_parent(
             )->grid_list_item( counter   = '{COUNTER}'
@@ -218,7 +218,7 @@ CLASS z2ui5_cl_demo_app_307 IMPLEMENTATION.
                                type      = '{TYPE}'
                                unread    = '{UNREAD}'
                 )->vbox( height = `100%`
-                    )->vbox( class = `sapUiSmallMargin`
+                    )->vbox( `sapUiSmallMargin`
                         )->layout_data(
                             )->flex_item_data( growfactor   = `1`
                                                shrinkfactor = `0`

--- a/src/z2ui5_cl_demo_app_312.clas.abap
+++ b/src/z2ui5_cl_demo_app_312.clas.abap
@@ -196,10 +196,10 @@ CLASS z2ui5_cl_demo_app_312 IMPLEMENTATION.
     DATA(lr_header_title) = lr_dyn_page->title( ns = 'f' )->get( )->dynamic_page_title( ).
 
     " ---------- Set header title text ----------------------------------------------------------------
-    lr_header_title->heading( ns = 'f' )->title( 'abap2UI5 - VizFrame Charts' ).
+    lr_header_title->heading( 'f' )->title( 'abap2UI5 - VizFrame Charts' ).
 
     " ---------- Get page header area ----------------------------------------------------------------
-    DATA(lr_header) = lr_dyn_page->header( ns = 'f' )->dynamic_page_header( pinnable = abap_true )->content( ns = 'f' ).
+    DATA(lr_header) = lr_dyn_page->header( 'f' )->dynamic_page_header( abap_true )->content( 'f' ).
 
     lr_header->button( text    = 'back'
                        press   = client->_event_nav_app_leave( )
@@ -224,7 +224,7 @@ CLASS z2ui5_cl_demo_app_312 IMPLEMENTATION.
                                        text = '{V}' ).
 
     " ---------- Get page content area ----------------------------------------------------------------
-    DATA(lr_content) = lr_dyn_page->content( ns = 'f' ).
+    DATA(lr_content) = lr_dyn_page->content( 'f' ).
 
     " ---------- Set vizframe chart -------------------------------------------------------------------
     DATA(lr_vizframe) = lr_content->viz_frame(
@@ -245,7 +245,7 @@ CLASS z2ui5_cl_demo_app_312 IMPLEMENTATION.
     DATA(lr_dataset) = lr_vizframe->viz_dataset( ).
 
     " ---------- Set vizframe flattened dataset --------------------------------------------------------
-    DATA(lr_flatteneddataset) = lr_dataset->viz_flattened_dataset( data = client->_bind( me->mt_data_chart ) ).
+    DATA(lr_flatteneddataset) = lr_dataset->viz_flattened_dataset( client->_bind( me->mt_data_chart ) ).
 
     " ---------- Set vizframe dimensions ---------------------------------------------------------------
     DATA(lr_dimensions) = lr_flatteneddataset->viz_dimensions( ).

--- a/src/z2ui5_cl_demo_app_316.clas.abap
+++ b/src/z2ui5_cl_demo_app_316.clas.abap
@@ -56,7 +56,7 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
     DATA(layout) = page->vertical_layout( class = `sapUiContentPadding`
                                           width = `100%` ).
 
-    DATA(email_form) = layout->simple_form( title = `Trigger E-Mail` ).
+    DATA(email_form) = layout->simple_form( `Trigger E-Mail` ).
 
     email_form->label( text     = `E-Mail`
                        labelfor = `inputEmail` ).
@@ -97,7 +97,7 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
                                                        t_arg = VALUE #( ( `TRIGGER_EMAIL` )
                                                                         ( |${ client->_bind_edit( email ) }| ) ) ) ).
 
-    DATA(telephone_form) = layout->simple_form( title = `Trigger Telephone` ).
+    DATA(telephone_form) = layout->simple_form( `Trigger Telephone` ).
 
     telephone_form->label( text     = `Telephone`
                            labelfor = `inputTel` ).
@@ -112,7 +112,7 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
                                        t_arg = VALUE #( ( `TRIGGER_TEL` )
                                                         ( |${ client->_bind_edit( phone ) }| ) ) ) ).
 
-    DATA(mobile_form) = layout->simple_form( title = `Trigger SMS` ).
+    DATA(mobile_form) = layout->simple_form( `Trigger SMS` ).
 
     mobile_form->label( text     = `Number`
                         labelfor = `inputNumber` ).
@@ -126,7 +126,7 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
                                                         t_arg = VALUE #( ( `TRIGGER_SMS` )
                                                                          ( |${ client->_bind_edit( mobile ) }| ) ) ) ).
 
-    DATA(url_form) = layout->simple_form( title = `Redirect` ).
+    DATA(url_form) = layout->simple_form( `Redirect` ).
     url_form->label( text     = `URL`
                      labelfor = `inputUrl` ).
     url_form->input( id          = `inputUrl`

--- a/src/z2ui5_cl_demo_app_317.clas.abap
+++ b/src/z2ui5_cl_demo_app_317.clas.abap
@@ -148,7 +148,7 @@ CLASS z2ui5_cl_demo_app_317 IMPLEMENTATION.
               )->core_custom_data( key   = 'ID'
                                    value = '{ID}').
 
-    tree->drag_drop_config( ns = `` )->drag_drop_info(
+    tree->drag_drop_config( `` )->drag_drop_info(
       sourceaggregation = `items`
       targetaggregation = `items`
       dragstart         = `Horizontal`

--- a/src/z2ui5_cl_demo_app_320.clas.abap
+++ b/src/z2ui5_cl_demo_app_320.clas.abap
@@ -150,25 +150,25 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
                                  contentwidth   = `250px`
                                  contentheight  = `332px`
         )->card(
-            )->content( ns = `f`
+            )->content( `f`
                 )->vertical_layout( class = `sapUiContentPadding`
                     )->hbox( alignitems = `Center`
                         )->avatar( src          = client->_bind( item-src )
                                    initials     = client->_bind( item-initials )
                                    badgetooltip = client->_bind( item-tooltip )
                                    fallbackicon = client->_bind( item-fallbackicon )
-                        )->vbox( class = `sapUiTinyMarginBegin`
-                            )->title( text = client->_bind( item-name )
-                            )->text( text = client->_bind( item-jobposition )
+                        )->vbox( `sapUiTinyMarginBegin`
+                            )->title( client->_bind( item-name )
+                            )->text( client->_bind( item-jobposition )
                         )->get_parent(
                     )->get_parent(
-                    )->title( text = `Contact Details`
-                    )->label( text = `Mobile`
-                    )->text( text = client->_bind( item-mobile )
-                    )->label( text = `Phone`
-                    )->text( text = client->_bind( item-phone )
-                    )->label( text = `Email`
-                    )->text( text = client->_bind( item-email ) ).
+                    )->title( `Contact Details`
+                    )->label( `Mobile`
+                    )->text( client->_bind( item-mobile )
+                    )->label( `Phone`
+                    )->text( client->_bind( item-phone )
+                    )->label( `Email`
+                    )->text( client->_bind( item-email ) ).
 
     client->popover_display( xml   = individual_popover->stringify( )
                              by_id = id ).
@@ -205,8 +205,8 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
                                                                              t_arg = VALUE #( ( `${ID}` ) ) )
                             )->get_parent(
                             )->vbox(
-                                )->text( text = `{NAME}`
-                                )->text( text = `{JOBPOSITION}` ).
+                                )->text( `{NAME}`
+                                )->text( `{JOBPOSITION}` ).
 
     nav_container->page( id             = `detail`
                          shownavbutton  = client->check_app_prev_stack( )
@@ -214,25 +214,25 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
                          titlealignment = `Center`
                          title          = |Team Members ({ lines( group_items ) })|
         )->card(
-            )->content( ns = `f`
+            )->content( `f`
                 )->vertical_layout( class = `sapUiContentPadding`
                     )->hbox( alignitems = `Center`
                         )->avatar( src          = client->_bind( item-src )
                                    initials     = client->_bind( item-initials )
                                    badgetooltip = client->_bind( item-tooltip )
                                    fallbackicon = client->_bind( item-fallbackicon )
-                        )->vbox( class = `sapUiTinyMarginBegin`
-                            )->title( text = client->_bind( item-name )
-                            )->text( text = client->_bind( item-jobposition )
+                        )->vbox( `sapUiTinyMarginBegin`
+                            )->title( client->_bind( item-name )
+                            )->text( client->_bind( item-jobposition )
                         )->get_parent(
                     )->get_parent(
-                    )->title( text = `Contact Details`
-                    )->label( text = `Mobile`
-                    )->text( text = client->_bind( item-mobile )
-                    )->label( text = `Phone`
-                    )->text( text = client->_bind( item-phone )
-                    )->label( text = `Email`
-                    )->text( text = client->_bind( item-email ) ).
+                    )->title( `Contact Details`
+                    )->label( `Mobile`
+                    )->text( client->_bind( item-mobile )
+                    )->label( `Phone`
+                    )->text( client->_bind( item-phone )
+                    )->label( `Email`
+                    )->text( client->_bind( item-email ) ).
 
     client->popover_display( xml   = view->stringify( )
                              by_id = id ).
@@ -247,7 +247,7 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
         content_height = calculate_content_height( lines( group_items ) ).
         content_width = '450px'.
 
-        display_group_popover( id = group_id ).
+        display_group_popover( group_id ).
         client->popover_destroy( ).
 
       WHEN `onIndividualPress`.
@@ -262,10 +262,10 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
         content_width = '450px'.
 
         IF overflow_button_pressed = abap_true.
-          display_group_popover( id = item_id ).
+          display_group_popover( item_id ).
         ELSE.
           item = VALUE #( items[ item_table_index + 1 ] OPTIONAL ).
-          display_individual_popover( id = item_id ).
+          display_individual_popover( item_id ).
         ENDIF.
         client->popover_destroy( ).
 

--- a/src/z2ui5_cl_demo_app_321.clas.abap
+++ b/src/z2ui5_cl_demo_app_321.clas.abap
@@ -18,7 +18,7 @@ CLASS z2ui5_cl_demo_app_321 IMPLEMENTATION.
 
     IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( val = view->shell(
+      client->view_display( view->shell(
              )->page(
                      title          = 'abap2UI5 - Navigation with app state'
                      navbuttonpress = client->_event( 'BACK' )

--- a/src/z2ui5_cl_demo_app_322.clas.abap
+++ b/src/z2ui5_cl_demo_app_322.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_demo_app_322 IMPLEMENTATION.
 
     IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( val = view->shell(
+      client->view_display( view->shell(
              )->page(
                      title          = 'abap2UI5 - Navigation with app state'
                      navbuttonpress = client->_event_client( 'HISTORY_BACK' )

--- a/src/z2ui5_cl_demo_app_323.clas.abap
+++ b/src/z2ui5_cl_demo_app_323.clas.abap
@@ -19,7 +19,7 @@ CLASS z2ui5_cl_demo_app_323 IMPLEMENTATION.
 
     IF client->check_on_navigated( ).
       DATA(view) = z2ui5_cl_xml_view=>factory( ).
-      client->view_display( val = view->shell(
+      client->view_display( view->shell(
              )->page(
                      title          = 'abap2UI5 - Navigation with app state'
                      navbuttonpress = client->_event( 'BACK' )

--- a/src/z2ui5_cl_demo_app_325.clas.abap
+++ b/src/z2ui5_cl_demo_app_325.clas.abap
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_demo_app_325 IMPLEMENTATION.
 
       sections->object_page_section( titleuppercase = abap_false
                                      id             = 'id_sec1'
-                                     title          = '...' )->heading( ns = `uxap`
+                                     title          = '...' )->heading( `uxap`
         )->get_parent( )->sub_sections( )->object_page_sub_section( id    = 'id_input'
                                                                     title = 'Input field'
         )->blocks( )->vbox(
@@ -49,7 +49,7 @@ CLASS z2ui5_cl_demo_app_325 IMPLEMENTATION.
 
       sections->object_page_section( titleuppercase = abap_false
                                      id             = 'id_sec2'
-                                     title          = '...' )->heading( ns = `uxap`
+                                     title          = '...' )->heading( `uxap`
         )->get_parent( )->sub_sections( )->object_page_sub_section( id    = 'id_text_area'
                                                                     title = 'Text area'
         )->blocks( )->vbox(

--- a/src/z2ui5_cl_demo_app_330.clas.abap
+++ b/src/z2ui5_cl_demo_app_330.clas.abap
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
         )->object_page_dyn_header_title( ).
 
     header_title->expanded_heading(
-                  )->title( text = `Robot Arm Series 9` ).
+                  )->title( `Robot Arm Series 9` ).
 
     header_title->snapped_heading(
                   )->hbox(
@@ -45,14 +45,14 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                            class        = `sapUiMediumMarginEnd`
                            displayshape = `Square`
                      )->vbox(
-                        )->title( text = `Robot Arm Series 9`
-                        )->label( text = `PO-48865` ).
+                        )->title( `Robot Arm Series 9`
+                        )->label( `PO-48865` ).
 
-    header_title->expanded_content( ns = `uxap`
-                  )->label( text = `PO-48865` ).
+    header_title->expanded_content( `uxap`
+                  )->label( `PO-48865` ).
 
     header_title->snapped_title_on_mobile(
-                  )->title( text = `Robot Arm Series 9` ).
+                  )->title( `Robot Arm Series 9` ).
 
     header_title->actions( 'uxap'
                   )->button( text = `Edit`
@@ -60,7 +60,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                   )->button( text = `Delete`
                   )->button( text = `Simulate Assembly` ).
 
-    DATA(header_content) = object_page_layout->header_content( ns = `uxap`
+    DATA(header_content) = object_page_layout->header_content( `uxap`
                                                )->flex_box( wrap         = `Wrap`
                                                             fitcontainer = abap_true ).
 
@@ -69,19 +69,19 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                             displayshape = `Square`
                             displaysize  = `L`
 
-                 )->vbox( class = `sapUiLargeMarginEnd sapUiSmallMarginBottom`
+                 )->vbox( `sapUiLargeMarginEnd sapUiSmallMarginBottom`
                     )->hbox( class      = `sapUiTinyMarginBottom`
                              rendertype = `Bare`
                        )->label( text  = `Manufacturer:`
                                  class = `sapUiTinyMarginEnd`
-                       )->text( text = `Robotech`
+                       )->text( `Robotech`
                     )->get_parent(
 
                     )->hbox( class      = `sapUiTinyMarginBottom`
                              rendertype = `Bare`
                        )->label( text  = `Factory:`
                                  class = `sapUiTinyMarginEnd`
-                       )->text( text = `Orlando, Florida`
+                       )->text( `Orlando, Florida`
                     )->get_parent(
 
                     )->hbox(
@@ -91,7 +91,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                     )->get_parent(
                  )->get_parent(
 
-                 )->vbox( class = `sapUiLargeMarginEnd sapUiSmallMarginBottom`
+                 )->vbox( `sapUiLargeMarginEnd sapUiSmallMarginBottom`
                     )->title( text  = `Status`
                               class = `sapUiTinyMarginBottom`
                     )->object_status( text  = `Delivery`
@@ -100,7 +100,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                     )->get_parent(
                  )->get_parent(
 
-                 )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+                 )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
                     )->title( text  = `Delivery Time`
                               class = `sapUiTinyMarginBottom`
                     )->object_status( text  = `12 Days`
@@ -109,7 +109,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                     )->get_parent(
                  )->get_parent(
 
-                 )->vbox( class = `sapUiSmallMarginEnd sapUiSmallMarginBottom`
+                 )->vbox( `sapUiSmallMarginEnd sapUiSmallMarginBottom`
                     )->title( text  = `Assembly Option`
                               class = `sapUiTinyMarginBottom`
                     )->object_status( text  = `To Be Selected`
@@ -118,7 +118,7 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                     )->get_parent(
                  )->get_parent(
 
-                 )->vbox( class = `sapUiLargeMarginEnd`
+                 )->vbox( `sapUiLargeMarginEnd`
                     )->title( text  = `Monthly Leasing Instalment`
                               class = `sapUiTinyMarginBottom`
                     )->object_number( number     = `379.99`
@@ -144,41 +144,41 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                                       )->title( ns   = `core`
                                                 text = `Order Details`
 
-                                      )->label( text = `Order ID`
-                                      )->text( text = `589946637`
+                                      )->label( `Order ID`
+                                      )->text( `589946637`
 
-                                      )->label( text = `Contract`
+                                      )->label( `Contract`
                                       )->link( text = `10045876`
 
-                                      )->label( text = `Transaction Date`
-                                      )->text( text = `May 6, 2018`
+                                      )->label( `Transaction Date`
+                                      )->text( `May 6, 2018`
 
-                                      )->label( text = `Expected Delivery Date`
-                                      )->text( text = `June 23, 2018`
+                                      )->label( `Expected Delivery Date`
+                                      )->text( `June 23, 2018`
 
-                                      )->label( text = `Factory`
-                                      )->text( text = `Orlando, FL`
+                                      )->label( `Factory`
+                                      )->text( `Orlando, FL`
 
-                                      )->label( text = `Supplier`
-                                      )->text( text = `Robotech`
+                                      )->label( `Supplier`
+                                      )->text( `Robotech`
 
                                       )->title( ns   = `core`
                                                 text = `Configuration Accounts`
 
-                                      )->label( text = `Model`
-                                      )->text( text = `Robot Arm Series 9`
+                                      )->label( `Model`
+                                      )->text( `Robot Arm Series 9`
 
-                                      )->label( text = `Color`
-                                      )->text( text = `White (default)`
+                                      )->label( `Color`
+                                      )->text( `White (default)`
 
-                                      )->label( text = `Socket`
-                                      )->text( text = `Default Socket 10`
+                                      )->label( `Socket`
+                                      )->text( `Default Socket 10`
 
-                                      )->label( text = `Leasing Instalment`
-                                      )->text( text = `379.99 USD per month`
+                                      )->label( `Leasing Instalment`
+                                      )->text( `379.99 USD per month`
 
-                                      )->label( text = `Axis`
-                                      )->text( text = `6 Axis`
+                                      )->label( `Axis`
+                                      )->text( `6 Axis`
                       )->get_parent(
                    )->get_parent(
                 )->get_parent(
@@ -211,60 +211,60 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
 
                          )->columns(
                             )->column(
-                               )->text( text = `Document Number`
+                               )->text( `Document Number`
                             )->get_parent(
                             )->column( minscreenwidth = `Tablet`
                                        demandpopin    = abap_true
-                               )->text( text = `Company`
+                               )->text( `Company`
                             )->get_parent(
                             )->column( minscreenwidth = `Tablet`
                                        demandpopin    = abap_true
-                               )->text( text = `Contact Person`
+                               )->text( `Contact Person`
                             )->get_parent(
                             )->column( minscreenwidth = `Tablet`
                                        demandpopin    = abap_true
-                               )->text( text = `Posting Date`
+                               )->text( `Posting Date`
                             )->get_parent(
                             )->column( halign = `End`
-                               )->text( text = `Amount (Local Currency)`
+                               )->text( `Amount (Local Currency)`
                             )->get_parent(
                          )->get_parent(
 
                          )->items(
                             )->column_list_item(
                                )->link( text = `10223882001820`
-                               )->text( text = `Jologa`
-                               )->text( text = `Denise Smith`
-                               )->text( text = `11/15/19`
-                               )->text( text = `12,897.00 EUR`
+                               )->text( `Jologa`
+                               )->text( `Denise Smith`
+                               )->text( `11/15/19`
+                               )->text( `12,897.00 EUR`
                             )->get_parent(
                             )->column_list_item(
                                )->link( text = `10223882001820`
-                               )->text( text = `Jologa`
-                               )->text( text = `Denise Smith`
-                               )->text( text = `11/15/19`
-                               )->text( text = `12,897.00 EUR`
+                               )->text( `Jologa`
+                               )->text( `Denise Smith`
+                               )->text( `11/15/19`
+                               )->text( `12,897.00 EUR`
                             )->get_parent(
                             )->column_list_item(
                                )->link( text = `10223882001820`
-                               )->text( text = `Jologa`
-                               )->text( text = `Denise Smith`
-                               )->text( text = `11/15/19`
-                               )->text( text = `12,897.00 EUR`
+                               )->text( `Jologa`
+                               )->text( `Denise Smith`
+                               )->text( `11/15/19`
+                               )->text( `12,897.00 EUR`
                             )->get_parent(
                             )->column_list_item(
                                )->link( text = `10223882001820`
-                               )->text( text = `Jologa`
-                               )->text( text = `Denise Smith`
-                               )->text( text = `11/15/19`
-                               )->text( text = `12,897.00 EUR`
+                               )->text( `Jologa`
+                               )->text( `Denise Smith`
+                               )->text( `11/15/19`
+                               )->text( `12,897.00 EUR`
                             )->get_parent(
                             )->column_list_item(
                                )->link( text = `10223882001820`
-                               )->text( text = `Jologa`
-                               )->text( text = `Denise Smith`
-                               )->text( text = `11/15/19`
-                               )->text( text = `12,897.00 EUR`
+                               )->text( `Jologa`
+                               )->text( `Denise Smith`
+                               )->text( `11/15/19`
+                               )->text( `12,897.00 EUR`
                             )->get_parent(
                          )->get_parent(
                       )->get_parent(
@@ -284,35 +284,35 @@ CLASS z2ui5_cl_demo_app_330 IMPLEMENTATION.
                                       )->title( ns   = `core`
                                                 text = `Phone Numbers`
 
-                                      )->label( text = `Home`
-                                      )->text( text = `+ 1 415-321-1234`
+                                      )->label( `Home`
+                                      )->text( `+ 1 415-321-1234`
 
-                                      )->label( text = `Office phone`
-                                      )->text( text = `+ 1 415-321-5555`
+                                      )->label( `Office phone`
+                                      )->text( `+ 1 415-321-5555`
 
                                       )->title( ns   = `core`
                                                 text = `Social Accounts`
 
-                                      )->label( text = `LinkedIn`
-                                      )->text( text = `/DeniseSmith`
+                                      )->label( `LinkedIn`
+                                      )->text( `/DeniseSmith`
 
-                                      )->label( text = `Twitter`
-                                      )->text( text = `@DeniseSmith`
+                                      )->label( `Twitter`
+                                      )->text( `@DeniseSmith`
 
                                       )->title( ns   = `core`
                                                 text = `Addresses`
 
-                                      )->label( text = `Home Address`
-                                      )->text( text = `2096 Mission Street`
+                                      )->label( `Home Address`
+                                      )->text( `2096 Mission Street`
 
-                                      )->label( text = `Mailing Address`
-                                      )->text( text = `PO Box 32114`
+                                      )->label( `Mailing Address`
+                                      )->text( `PO Box 32114`
 
                                       )->title( ns   = `core`
                                                 text = `Mailing Address`
 
-                                      )->label( text = `Work`
-                                      )->text( text = `DeniseSmith@sap.com`
+                                      )->label( `Work`
+                                      )->text( `DeniseSmith@sap.com`
 
                       )->get_parent(
                    )->get_parent(

--- a/src/z2ui5_cl_demo_app_331.clas.abap
+++ b/src/z2ui5_cl_demo_app_331.clas.abap
@@ -48,7 +48,7 @@ CLASS z2ui5_cl_demo_app_331 IMPLEMENTATION.
     DATA(form) = page->simple_form( editable        = abap_true
                                     layout          = `ResponsiveGridLayout`
                                     adjustlabelspan = abap_true
-                              )->content( ns = `form` ).
+                              )->content( `form` ).
 
     ASSIGN mo_table_obj->mr_data->* TO FIELD-SYMBOL(<val>).
     ASSIGN COMPONENT 'ID' OF STRUCTURE <val> TO FIELD-SYMBOL(<value>).
@@ -59,7 +59,7 @@ CLASS z2ui5_cl_demo_app_331 IMPLEMENTATION.
     DATA(line) = form->label( wrapping = abap_false
                               text     = 'ID' ).
 
-    line->input( value = client->_bind( <value> ) ).
+    line->input( client->_bind( <value> ) ).
 
     client->view_display( page->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_332.clas.abap
+++ b/src/z2ui5_cl_demo_app_332.clas.abap
@@ -53,7 +53,7 @@ CLASS z2ui5_cl_demo_app_332 IMPLEMENTATION.
     DATA(form) = page->simple_form( editable        = abap_true
                                     layout          = `ResponsiveGridLayout`
                                     adjustlabelspan = abap_true
-                              )->content( ns = `form` ).
+                              )->content( `form` ).
 
     DATA(index) = 0.
 

--- a/src/z2ui5_cl_demo_app_334.clas.abap
+++ b/src/z2ui5_cl_demo_app_334.clas.abap
@@ -68,7 +68,7 @@ CLASS z2ui5_cl_demo_app_334 IMPLEMENTATION.
     DATA(form) = page->simple_form( editable        = abap_true
                                     layout          = `ResponsiveGridLayout`
                                     adjustlabelspan = abap_true
-                              )->content( ns = `form` ).
+                              )->content( `form` ).
 
     DATA(index) = 0.
 

--- a/src/z2ui5_cl_demo_app_335.clas.abap
+++ b/src/z2ui5_cl_demo_app_335.clas.abap
@@ -87,7 +87,7 @@ CLASS z2ui5_cl_demo_app_335 IMPLEMENTATION.
     DATA(form) = page->simple_form( editable        = abap_true
                                     layout          = `ResponsiveGridLayout`
                                     adjustlabelspan = abap_true
-                              )->content( ns = `form` ).
+                              )->content( `form` ).
 
     DATA(index) = 0.
 

--- a/src/z2ui5_cl_demo_app_337.clas.abap
+++ b/src/z2ui5_cl_demo_app_337.clas.abap
@@ -167,7 +167,7 @@ CLASS z2ui5_cl_demo_app_337 IMPLEMENTATION.
     DATA(form) = i_page->simple_form( editable        = abap_true
                                       layout          = `ResponsiveGridLayout`
                                       adjustlabelspan = abap_true
-                                 )->content( ns = `form` ).
+                                 )->content( `form` ).
 
     DATA(index) = 0.
 

--- a/src/z2ui5_cl_demo_app_340.clas.abap
+++ b/src/z2ui5_cl_demo_app_340.clas.abap
@@ -51,7 +51,7 @@ CLASS z2ui5_cl_demo_app_340 IMPLEMENTATION.
           )->simple_form( title    = ''
                           layout   = 'ResponsiveGridLayout'
                           editable = abap_true
-          )->content( ns = 'form' )->label( text = 'Test' )->input( value = 'TEST' ).
+          )->content( 'form' )->label( 'Test' )->input( 'TEST' ).
 
     client->popup_display( popup->stringify( ) ).
 

--- a/src/z2ui5_cl_demo_app_346.clas.abap
+++ b/src/z2ui5_cl_demo_app_346.clas.abap
@@ -93,7 +93,7 @@ CLASS z2ui5_cl_demo_app_346 IMPLEMENTATION.
             shownavbutton  = abap_true ).
 
     DATA(tab) = page->table(
-            items = client->_bind_edit( t_tab )
+            client->_bind_edit( t_tab )
         )->header_toolbar(
             )->overflow_toolbar(
                 )->label( `Column Id` )->input( submit      = client->_event( 'FOCUS' )
@@ -114,7 +114,7 @@ CLASS z2ui5_cl_demo_app_346 IMPLEMENTATION.
                 )->button(
                     text  = 'Reset Focus'
                     press = client->_event( 'RESET' )
-                )->title( text = client->_bind( focusid )
+                )->title( client->_bind( focusid )
                 )->toolbar_spacer(
         )->get_parent( )->get_parent( ).
 
@@ -134,7 +134,7 @@ CLASS z2ui5_cl_demo_app_346 IMPLEMENTATION.
 
     tab->items( )->column_list_item( selected = '{SELKZ}'
       )->cells(
-          )->text( text = '{INDEX}'
+          )->text( '{INDEX}'
           )->input( value  = '{TITLE}'
                     submit = client->_event( 'ENTER' )
           )->get( )->custom_data( )->core_custom_data(
@@ -156,7 +156,7 @@ CLASS z2ui5_cl_demo_app_346 IMPLEMENTATION.
                      value      = c_id-info
                      writetodom = abap_true
           )->get_parent( )->get_parent(
-          )->checkbox( selected = '{CHECKBOX}'
+          )->checkbox( '{CHECKBOX}'
           )->get( )->custom_data( )->core_custom_data(
                      key        = 'ColumnId'
                      value      = c_id-checkbox

--- a/src/z2ui5_cl_demo_app_349.clas.abap
+++ b/src/z2ui5_cl_demo_app_349.clas.abap
@@ -157,7 +157,7 @@ CLASS z2ui5_cl_demo_app_349 IMPLEMENTATION.
     DATA(form) = i_page->simple_form( editable        = abap_true
                                       layout          = `ResponsiveGridLayout`
                                       adjustlabelspan = abap_true
-                                 )->content( ns = `form` ).
+                                 )->content( `form` ).
 
     DATA(index) = 0.
 

--- a/src/z2ui5_cl_demo_app_350.clas.abap
+++ b/src/z2ui5_cl_demo_app_350.clas.abap
@@ -29,7 +29,7 @@ CLASS z2ui5_cl_demo_app_350 IMPLEMENTATION.
           IF client->check_on_init( ) OR client->check_on_navigated( ).
             DATA(view) = z2ui5_cl_xml_view=>factory( ).
             DATA(page) = view->shell( )->page(
-              title = `Startview` ).
+              `Startview` ).
             page->simple_form(
                   )->content( 'form'
                                )->button(
@@ -124,7 +124,7 @@ CLASS z2ui5_cl_demo_app_350 IMPLEMENTATION.
     DATA(vbox) = page->vbox( ).
     DATA(hbox) = vbox->hbox( alignitems = 'Center' ).
     hbox->title(
-      text = 'Current Lock Value in Table ZTEST' ).
+      'Current Lock Value in Table ZTEST' ).
     hbox->input(
       editable = abap_false
       value    = client->_bind_edit( varkey ) ).

--- a/src/z2ui5_cl_demo_app_351.clas.locals_imp.abap
+++ b/src/z2ui5_cl_demo_app_351.clas.locals_imp.abap
@@ -30,7 +30,7 @@ CLASS zcl_2ui5_start IMPLEMENTATION.
         IF client->check_on_init( ) OR client->check_on_navigated( )..
           DATA(view) = z2ui5_cl_xml_view=>factory( ).
           DATA(page) = view->shell( )->page(
-            title = `Startview` ).
+            `Startview` ).
           page->simple_form(
                 )->content( 'form'
                              )->button(
@@ -72,7 +72,7 @@ CLASS zcl_2ui5_lock IMPLEMENTATION.
     DATA(vbox) = page->vbox( ).
     DATA(hbox) = vbox->hbox( alignitems = 'Center' ).
     hbox->title(
-      text = 'Current Lock Value in Table ZTEST' ).
+      'Current Lock Value in Table ZTEST' ).
     hbox->input(
       editable = abap_false
       value    = client->_bind_edit( varkey ) ).

--- a/src/z2ui5_cl_demo_app_352.clas.abap
+++ b/src/z2ui5_cl_demo_app_352.clas.abap
@@ -44,7 +44,7 @@ CLASS z2ui5_cl_demo_app_352 IMPLEMENTATION.
              )->page( title          = 'abap2UI5 - Softkeyboard on/off'
                       navbuttonpress = client->_event_nav_app_leave( )
                       shownavbutton  = client->check_app_prev_stack( )
-                      )->_z2ui5( )->focus( focusid = `ZINPUT`
+                      )->_z2ui5( )->focus( `ZINPUT`
       )->simple_form( editable = abap_true
                  )->content( 'form'
                      )->title( 'Keyboard on/off'

--- a/src/z2ui5_cl_demo_app_353.clas.abap
+++ b/src/z2ui5_cl_demo_app_353.clas.abap
@@ -74,11 +74,11 @@ CLASS z2ui5_cl_demo_app_353 IMPLEMENTATION.
                                     device_height     = client->_bind_edit( device_height )
                                     device_width      = client->_bind_edit( device_width ) ).
 
-    DATA(form) = page->_z2ui5( )->focus( focusid = client->_bind( focus_field )
+    DATA(form) = page->_z2ui5( )->focus( client->_bind( focus_field )
 
           )->simple_form( editable = abap_true
 
-                                )->content( ns = `form` ).
+                                )->content( `form` ).
 
     form->label( 'device_browser'
                           )->input( client->_bind_edit( device_os )


### PR DESCRIPTION
## Summary
This PR refactors method calls throughout the codebase to use positional parameters instead of named parameters where applicable. This improves code consistency and aligns with the project's coding standards.

## Key Changes
- **Parameter name removal**: Removed explicit parameter names (e.g., `text =`, `ns =`, `class =`, `val =`, `content =`, `label =`) from method calls, passing values as positional arguments instead
- **Affected methods**: Updated calls across numerous UI component methods including:
  - `label()`, `text()`, `title()` - removed `text =` parameter name
  - `expanded_content()`, `snapped_content()`, `header_content()` - removed `ns =` parameter name
  - `vbox()`, `hbox()` - removed `class =` parameter name
  - `follow_up_action()`, `_bind()` - removed `val =` parameter name
  - `html()` - removed `content =` parameter name
  - `input_list_item()` - removed `label =` parameter name
  - And many other UI component methods

- **Scope**: Changes applied across 60+ demo application files (z2ui5_cl_demo_app_*.clas.abap)

- **Linting rules**: Added two new abaplint rules to enforce this pattern:
  - `"exporting": true` - enforce exporting parameter style
  - `"omit_parameter_name": true` - enforce omitting parameter names in method calls

## Implementation Details
- All changes maintain functional equivalence - only the calling convention is modified
- The refactoring is systematic across the entire codebase, ensuring consistency
- No logic changes or behavioral modifications were made

https://claude.ai/code/session_01BGLgdc59BY3fxHJy4Eei7v