### PR TITLE
Refactor demo app to inline main method and update style guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Use backticks for all string literals, not single quotes.
 - Class names are always written in **lowercase** in both `DEFINITION` and `IMPLEMENTATION` — never uppercase.
 - Classes are **not** `FINAL` — do not add the `FINAL` keyword to class definitions.
+- Always include `PROTECTED SECTION.` and `PRIVATE SECTION.` in the class definition, even if empty.
 
 ## Framework Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Always include `PROTECTED SECTION.` and `PRIVATE SECTION.` in the class definition, even if empty.
 - No blank lines between `SECTION.` keywords, between methods, or between `CLASS`/`ENDCLASS` — use compact formatting without extra empty lines.
 - Always run `abaplint` after every change. It must report 0 issues before committing.
+- Before starting app development, read all active rules in `abaplint.jsonc` and follow them throughout.
 
 ## Framework Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Classes are **not** `FINAL` — do not add the `FINAL` keyword to class definitions.
 - Always include `PROTECTED SECTION.` and `PRIVATE SECTION.` in the class definition, even if empty.
 - No blank lines between `SECTION.` keywords, between methods, or between `CLASS`/`ENDCLASS` — use compact formatting without extra empty lines.
+- Always run `abaplint` after every change. It must report 0 issues before committing.
 
 ## Framework Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,17 @@ Every abap2UI5 app implements `z2ui5_if_app` with a single `main()` method. The 
 - `client->check_on_navigated( )` — true when returning from a sub-app or popup
 - `client->check_on_event( )` — true when a user triggered an event
 
+Always use `ELSEIF` to chain these checks — never separate `IF` blocks:
+```abap
+IF client->check_on_init( ).
+  ...
+ELSEIF client->check_on_navigated( ).
+  ...
+ELSEIF client->check_on_event( ).
+  ...
+ENDIF.
+```
+
 ### Client API (`z2ui5_if_client`)
 
 | Category | Methods | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Never use an init flag attribute (`check_initialized`, `mv_init`, `is_initialized`, etc.). Always use `client->check_on_init( )` instead.
 - Use backticks for all string literals, not single quotes.
 
+## Framework Reference
+
+For deeper information about how the abap2UI5 framework works internally — architecture, roundtrip processing, data binding engine, session persistence, and core classes — refer to the [abap2UI5 repository](https://github.com/abap2UI5/abap2UI5) and its `CLAUDE.md`.
+
 ## How Apps Work
 
 Every abap2UI5 app implements `z2ui5_if_app` with a single `main()` method. The framework calls `main()` on every roundtrip (HTTP POST). Use the lifecycle checks to react to different situations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,9 @@ Every abap2UI5 app implements `z2ui5_if_app` with a single `main()` method. The 
 
 ## App Structure
 
-### Simple apps (< 50 lines total)
+### Simple apps (< 50 lines in `main`)
 
-Write everything directly in `main` — no method encapsulation needed.
+Write everything directly in `main` — no method encapsulation needed. Count only the lines inside the `main` method, not the total class length.
 
 ### Larger apps — canonical template
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Follow the [SAP ABAP Style Guide](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md).
 - Never use an init flag attribute (`check_initialized`, `mv_init`, `is_initialized`, etc.). Always use `client->check_on_init( )` instead.
 - Use backticks for all string literals, not single quotes.
+- Class names are always written in **lowercase** in both `DEFINITION` and `IMPLEMENTATION` — never uppercase.
+- Classes are **not** `FINAL` — do not add the `FINAL` keyword to class definitions.
 
 ## Framework Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
 - Class names are always written in **lowercase** in both `DEFINITION` and `IMPLEMENTATION` — never uppercase.
 - Classes are **not** `FINAL` — do not add the `FINAL` keyword to class definitions.
 - Always include `PROTECTED SECTION.` and `PRIVATE SECTION.` in the class definition, even if empty.
+- No blank lines between `SECTION.` keywords, between methods, or between `CLASS`/`ENDCLASS` — use compact formatting without extra empty lines.
 
 ## Framework Reference
 
@@ -79,27 +80,21 @@ The following is the **maximum structure**. Only add methods that are actually n
 
 ```abap
 CLASS z2ui5_cl_app_xxx DEFINITION PUBLIC CREATE PUBLIC.
-
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
     " bound data (DATA attributes for _bind/_bind_edit)...
-
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
-
     METHODS on_init.        " first call: load data, display view
     METHODS on_event.       " user triggered an event
     METHODS on_navigation.  " returned from sub-app or popup
     METHODS view_display.   " build and render the view
     METHODS data_read.      " SELECT from database
     METHODS data_update.    " INSERT / UPDATE / DELETE
-
   PRIVATE SECTION.
-
 ENDCLASS.
 
 CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
-
   METHOD z2ui5_if_app~main.
     me->client = client.
     IF client->check_on_init( ).
@@ -110,17 +105,14 @@ CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
       on_event( ).
     ENDIF.
   ENDMETHOD.
-
   METHOD on_init.
     data_read( ).
     view_display( ).
   ENDMETHOD.
-
   METHOD on_navigation.
     data_read( ).
     client->view_model_update( ).
   ENDMETHOD.
-
   METHOD on_event.
     CASE client->get( )-event.
       WHEN `SAVE`.
@@ -129,20 +121,16 @@ CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
         client->nav_app_leave( ).
     ENDCASE.
   ENDMETHOD.
-
   METHOD view_display.
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
     " ...
     client->view_display( view->stringify( ) ).
   ENDMETHOD.
-
   METHOD data_read.
     " SELECT ...
   ENDMETHOD.
-
   METHOD data_update.
     " INSERT / UPDATE / DELETE ...
   ENDMETHOD.
-
 ENDCLASS.
 ```

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -30,7 +30,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
                   press = client->_event( `BUTTON_POST` ) ).
       client->view_display( view->stringify( ) ).
     ELSEIF client->check_on_event( `BUTTON_POST` ).
-      client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
+      client->message_toast_display( |{ product } { quantity } - send to the server| ).
     ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -1,23 +1,14 @@
 CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC CREATE PUBLIC.
-
   PUBLIC SECTION.
-
     INTERFACES z2ui5_if_app.
-
     DATA product  TYPE string.
     DATA quantity TYPE string.
-
   PROTECTED SECTION.
-
   PRIVATE SECTION.
-
 ENDCLASS.
 
-
 CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
-
   METHOD z2ui5_if_app~main.
-
     IF client->check_on_init( ).
       product  = `products`.
       quantity = `500`.
@@ -41,7 +32,5 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
     ELSEIF client->check_on_event( `BUTTON_POST` ).
       client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
     ENDIF.
-
   ENDMETHOD.
-
 ENDCLASS.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -17,11 +17,12 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
     IF client->check_on_init( ).
       product  = `products`.
       quantity = `500`.
-      client->view_display( z2ui5_cl_xml_view=>factory(
-           )->shell( )->page(
-                   title          = `abap2UI5 - First Example`
-                   navbuttonpress = client->_event_nav_app_leave( )
-                   shownavbutton  = client->check_app_prev_stack( )
+      DATA(view) = z2ui5_cl_xml_view=>factory( ).
+      view->shell(
+          )->page(
+              title          = `abap2UI5 - First Example`
+              navbuttonpress = client->_event_nav_app_leave( )
+              shownavbutton  = client->check_app_prev_stack( )
           )->simple_form( title = `Form Title` editable = abap_true
           )->content( `form`
               )->title( `Input`
@@ -31,8 +32,8 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
               )->input( value = product enabled = abap_false
               )->button(
                   text  = `post`
-                  press = client->_event( `BUTTON_POST` )
-          )->stringify( ) ).
+                  press = client->_event( `BUTTON_POST` ) ).
+      client->view_display( view->stringify( ) ).
     ELSEIF client->check_on_event( `BUTTON_POST` ).
       client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -7,78 +7,38 @@ CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC CREATE PUBLIC.
     DATA product  TYPE string.
     DATA quantity TYPE string.
 
-
-  PROTECTED SECTION.
-
-    DATA client TYPE REF TO z2ui5_if_client.
-
-    METHODS z2ui5_set_data.
-
-    METHODS display_view
-      IMPORTING
-        client TYPE REF TO z2ui5_if_client.
-    METHODS on_event
-      IMPORTING
-        client TYPE REF TO z2ui5_if_client.
-
-  PRIVATE SECTION.
 ENDCLASS.
-
 
 
 CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    me->client = client.
-
-
     IF client->check_on_init( ).
-      display_view( client ).
-      z2ui5_set_data( ).
-    ENDIF.
-
-    on_event( client ).
-
-  ENDMETHOD.
-
-
-  METHOD display_view.
-
-    DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( val = view->shell(
-           )->page(
-                   title          = 'abap2UI5 - First Example'
+      product  = `products`.
+      quantity = `500`.
+      client->view_display( z2ui5_cl_xml_view=>factory(
+           )->shell( )->page(
+                   title          = `abap2UI5 - First Example`
                    navbuttonpress = client->_event_nav_app_leave( )
                    shownavbutton  = client->check_app_prev_stack( )
-        )->simple_form( title = 'Form Title' editable = abap_true
-                   )->content( 'form'
-                       )->title( 'Input'
-                       )->label( 'quantity'
-                       )->input( client->_bind_edit( quantity )
-                       )->label( `product`
-                       )->input( value = product enabled = abap_false
-                       )->button(
-                           text  = 'post'
-                           press = client->_event( 'BUTTON_POST' )
-            )->stringify( ) ).
+          )->simple_form( title = `Form Title` editable = abap_true
+          )->content( `form`
+              )->title( `Input`
+              )->label( `quantity`
+              )->input( client->_bind_edit( quantity )
+              )->label( `product`
+              )->input( value = product enabled = abap_false
+              )->button(
+                  text  = `post`
+                  press = client->_event( `BUTTON_POST` )
+          )->stringify( ) ).
+    ENDIF.
 
-  ENDMETHOD.
-
-
-  METHOD on_event.
-
-    IF client->check_on_event( 'BUTTON_POST' ).
+    IF client->check_on_event( `BUTTON_POST` ).
       client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
     ENDIF.
 
   ENDMETHOD.
 
-
-  METHOD z2ui5_set_data.
-
-    product  = 'products'.
-    quantity = '500'.
-
-  ENDMETHOD.
 ENDCLASS.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -33,9 +33,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
                   text  = `post`
                   press = client->_event( `BUTTON_POST` )
           )->stringify( ) ).
-    ENDIF.
-
-    IF client->check_on_event( `BUTTON_POST` ).
+    ELSEIF client->check_on_event( `BUTTON_POST` ).
       client->message_toast_display( text = |{ product } { quantity } - send to the server| ).
     ENDIF.
 

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -7,6 +7,10 @@ CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC CREATE PUBLIC.
     DATA product  TYPE string.
     DATA quantity TYPE string.
 
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+
 ENDCLASS.
 
 


### PR DESCRIPTION
## Summary
Refactored `z2ui5_cl_demo_app_001` to consolidate all logic into the `main()` method, removing unnecessary helper methods and reducing code complexity. Updated the style guide documentation to reflect current best practices for app structure and formatting.

## Key Changes

**Code Changes:**
- Inlined `display_view()` and `on_event()` methods directly into `main()`
- Removed `z2ui5_set_data()` method; data initialization now happens inline
- Removed unused `client` instance variable from PROTECTED SECTION
- Simplified control flow by using `ELSEIF` instead of separate method calls
- Converted all string literals from single quotes to backticks
- Removed excessive blank lines for compact formatting
- Kept empty PROTECTED and PRIVATE sections per style guide

**Documentation Changes:**
- Added explicit style rules: lowercase class names, no FINAL keyword, mandatory empty sections
- Clarified compact formatting requirements (no blank lines between sections/methods)
- Added requirement to run `abaplint` before committing
- Documented the `ELSEIF` chaining pattern for `client->check_*()` calls
- Updated app structure guidance: simple apps should be < 50 lines in `main()` only
- Provided canonical template with proper formatting examples
- Added reference to main abap2UI5 repository for framework internals

## Implementation Details
The refactored app now demonstrates the "simple app" pattern where all logic fits directly in `main()` without helper methods. The view is built and displayed inline, and event handling uses `ELSEIF` chaining for clarity. This serves as a better example for developers building small demo applications.

https://claude.ai/code/session_01NVK2NpLDKnZpiGcrz9w4uf