### PR TITLE
Add demo app 354: Generic XML builder example with form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,37 @@ ENDIF.
 | Info | `get()`, `get_event_arg()`, `get_app(id)` | Request/context data |
 | Constants | `cs_event`, `cs_view` | Predefined event IDs and view names |
 
+## Building Views
+
+Views are XML strings passed to `client->view_display()`. There are two ways to build them:
+
+### 1. `z2ui5_cl_xml_view` — typed fluent API
+Pre-built methods for common UI5 controls (`shell`, `page`, `simple_form`, `input`, `button`, etc.). Use this for standard layouts.
+
+### 2. `z2ui5_cl_util_xml` — generic XML builder
+Builds any XML structure directly from element names, namespaces and attributes. **Look up the control in the [UI5 API Reference](https://ui5.sap.com/#/api) and translate 1:1 to ABAP** — no wrapper, no abstraction layer.
+
+```abap
+" UI5 XML:                              " ABAP:
+" <form:SimpleForm title="T"            ->_( n = `SimpleForm` ns = `form` p = VALUE #(
+"   editable="true">                         ( n = `title`    v = `T` )
+"   <form:content>                           ( n = `editable` v = abap_true ) )
+"     <Label text="qty"/>              )->_( n = `content` ns = `form`
+"     <Input value="{...}"/>           )->__( n = `Label` a = `text` v = `qty`
+"   </form:content>                    )->__( n = `Input` a = `value` v = client->_bind_edit( qty ) )
+" </form:SimpleForm>
+```
+
+Key rules for `z2ui5_cl_util_xml`:
+- `_( n, ns, p )` — add child element, navigate **into** it
+- `__( n, ns, a, v, p )` — add child element, **stay** at current level
+- `p( n, v )` — add a single attribute to current element
+- Single attribute: use `a = ... v = ...` parameters directly
+- Multiple attributes: use `p = VALUE #( ( n = ... v = ... ) ... )`
+- Namespace declarations go on the root `mvc:View` element as regular attributes (`xmlns:form`, etc.)
+- Only declare namespaces that are actually used in the view
+- `stringify()` on the factory root produces the complete XML string
+
 ## App Structure
 
 ### Simple apps (< 50 lines in `main`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,15 +80,24 @@ Pre-built methods for common UI5 controls (`shell`, `page`, `simple_form`, `inpu
 ### 2. `z2ui5_cl_util_xml` — generic XML builder
 Builds any XML structure directly from element names, namespaces and attributes. **Look up the control in the [UI5 API Reference](https://ui5.sap.com/#/api) and translate 1:1 to ABAP** — no wrapper, no abstraction layer.
 
+**UI5 XML:**
+```xml
+<form:SimpleForm title="T" editable="true">
+  <form:content>
+    <Label text="qty"/>
+    <Input value="{...}"/>
+  </form:content>
+</form:SimpleForm>
+```
+
+**ABAP:**
 ```abap
-" UI5 XML:                              " ABAP:
-" <form:SimpleForm title="T"            ->_( n = `SimpleForm` ns = `form` p = VALUE #(
-"   editable="true">                         ( n = `title`    v = `T` )
-"   <form:content>                           ( n = `editable` v = abap_true ) )
-"     <Label text="qty"/>              )->_( n = `content` ns = `form`
-"     <Input value="{...}"/>           )->__( n = `Label` a = `text` v = `qty`
-"   </form:content>                    )->__( n = `Input` a = `value` v = client->_bind_edit( qty ) )
-" </form:SimpleForm>
+->_( n = `SimpleForm` ns = `form` p = VALUE #(
+        ( n = `title`    v = `T` )
+        ( n = `editable` v = abap_true ) )
+)->_( n = `content` ns = `form`
+)->__( n = `Label` a = `text` v = `qty`
+)->__( n = `Input` a = `value` v = client->_bind_edit( qty ) )
 ```
 
 Key rules for `z2ui5_cl_util_xml`:

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -12,38 +12,33 @@ CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
     IF client->check_on_init( ).
       product  = `products`.
       quantity = `500`.
-      DATA(lt_ns) = VALUE z2ui5_cl_util=>ty_t_name_value(
-          ( n = `displayBlock` v = `true` )
-          ( n = `height`       v = `100%` )
-          ( n = `xmlns`        v = `sap.m` )
-          ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
-          ( n = `xmlns:core`   v = `sap.ui.core` )
-          ( n = `xmlns:form`   v = `sap.ui.layout.form` ) ).
-      DATA(lt_page) = VALUE z2ui5_cl_util=>ty_t_name_value(
-          ( n = `title`          v = `abap2UI5 - First Example` )
-          ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
-          ( n = `showNavButton`  v = client->check_app_prev_stack( ) ) ).
-      DATA(lt_form) = VALUE z2ui5_cl_util=>ty_t_name_value(
-          ( n = `title`    v = `Form Title` )
-          ( n = `editable` v = abap_true ) ).
       DATA(view) = z2ui5_cl_util_xml=>factory( ).
-      DATA(lo_content) = view->_( n = `View` ns = `mvc` p = lt_ns
-          )->_( `Shell`
-          )->_( n = `Page` p = lt_page
-          )->_( n = `SimpleForm` ns = `form` p = lt_form
-          )->_( n = `content` ns = `form` ).
+      DATA(lo_content) = view->_( n = `View` ns = `mvc` p = VALUE #(
+                                      ( n = `displayBlock` v = `true` )
+                                      ( n = `height`       v = `100%` )
+                                      ( n = `xmlns`        v = `sap.m` )
+                                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
+                                      ( n = `xmlns:core`   v = `sap.ui.core` )
+                                      ( n = `xmlns:form`   v = `sap.ui.layout.form` ) )
+                              )->_( `Shell`
+                              )->_( n = `Page` p = VALUE #(
+                                      ( n = `title`          v = `abap2UI5 - First Example` )
+                                      ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
+                                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) ) )
+                              )->_( n = `SimpleForm` ns = `form` p = VALUE #(
+                                      ( n = `title`    v = `Form Title` )
+                                      ( n = `editable` v = abap_true ) )
+                              )->_( n = `content` ns = `form` ).
       lo_content->__( n = `Title` a = `text` v = `Input`
                )->__( n = `Label` a = `text` v = `quantity`
                )->__( n = `Input` a = `value` v = client->_bind_edit( quantity )
-               )->__( n = `Label` a = `text` v = `product` ).
-      lo_content->__( n = `Input`
-          p = VALUE #(
-                ( n = `value`   v = product )
-                ( n = `enabled` v = `false` ) ) ).
-      lo_content->__( n = `Button`
-          p = VALUE #(
-                ( n = `text`  v = `post` )
-                ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
+               )->__( n = `Label` a = `text` v = `product`
+               )->__( n = `Input` p = VALUE #(
+                         ( n = `value`   v = product )
+                         ( n = `enabled` v = `false` ) )
+               )->__( n = `Button` p = VALUE #(
+                         ( n = `text`  v = `post` )
+                         ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
       client->view_display( view->stringify( ) ).
     ELSEIF client->check_on_event( `BUTTON_POST` ).
       client->message_toast_display( |{ product } { quantity } - send to the server| ).

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -18,7 +18,6 @@ CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
                                       ( n = `height`       v = `100%` )
                                       ( n = `xmlns`        v = `sap.m` )
                                       ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
-                                      ( n = `xmlns:core`   v = `sap.ui.core` )
                                       ( n = `xmlns:form`   v = `sap.ui.layout.form` ) )
                               )->_( `Shell`
                               )->_( n = `Page` p = VALUE #(

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -1,0 +1,48 @@
+CLASS z2ui5_cl_demo_app_354 DEFINITION PUBLIC CREATE PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+    DATA product  TYPE string.
+    DATA quantity TYPE string.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
+  METHOD z2ui5_if_app~main.
+    IF client->check_on_init( ).
+      product  = `products`.
+      quantity = `500`.
+      DATA(view)       = z2ui5_cl_util_xml=>factory( ).
+      DATA(lo_view)    = view->_( n = `View` ns = `mvc` ).
+      lo_view->p( n = `displayBlock` v = `true` ).
+      lo_view->p( n = `height` v = `100%` ).
+      lo_view->p( n = `xmlns` v = `sap.m` ).
+      lo_view->p( n = `xmlns:mvc` v = `sap.ui.core.mvc` ).
+      lo_view->p( n = `xmlns:core` v = `sap.ui.core` ).
+      lo_view->p( n = `xmlns:form` v = `sap.ui.layout.form` ).
+      DATA(lo_page)    = lo_view->_( `Shell` )->_( `Page` ).
+      lo_page->p( n = `title` v = `abap2UI5 - First Example` ).
+      lo_page->p( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
+      lo_page->p( n = `showNavButton` v = client->check_app_prev_stack( ) ).
+      DATA(lo_form)    = lo_page->_( n = `SimpleForm` ns = `form` ).
+      lo_form->p( n = `title` v = `Form Title` ).
+      lo_form->p( n = `editable` v = abap_true ).
+      DATA(lo_content) = lo_form->_( n = `content` ns = `form` ).
+      lo_content->__( n = `Title` a = `text` v = `Input` ).
+      lo_content->__( n = `Label` a = `text` v = `quantity` ).
+      lo_content->__( n = `Input` a = `value` v = client->_bind_edit( quantity ) ).
+      lo_content->__( n = `Label` a = `text` v = `product` ).
+      lo_content->__( n = `Input`
+          p = VALUE z2ui5_cl_util=>ty_t_name_value(
+                ( n = `value` v = product )
+                ( n = `enabled` v = `false` ) ) ).
+      lo_content->__( n = `Button`
+          p = VALUE z2ui5_cl_util=>ty_t_name_value(
+                ( n = `text` v = `post` )
+                ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
+      client->view_display( view->stringify( ) ).
+    ELSEIF client->check_on_event( `BUTTON_POST` ).
+      client->message_toast_display( |{ product } { quantity } - send to the server| ).
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -12,33 +12,37 @@ CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
     IF client->check_on_init( ).
       product  = `products`.
       quantity = `500`.
-      DATA(view)       = z2ui5_cl_util_xml=>factory( ).
-      DATA(lo_view)    = view->_( n = `View` ns = `mvc` ).
-      lo_view->p( n = `displayBlock` v = `true` ).
-      lo_view->p( n = `height` v = `100%` ).
-      lo_view->p( n = `xmlns` v = `sap.m` ).
-      lo_view->p( n = `xmlns:mvc` v = `sap.ui.core.mvc` ).
-      lo_view->p( n = `xmlns:core` v = `sap.ui.core` ).
-      lo_view->p( n = `xmlns:form` v = `sap.ui.layout.form` ).
-      DATA(lo_page)    = lo_view->_( `Shell` )->_( `Page` ).
-      lo_page->p( n = `title` v = `abap2UI5 - First Example` ).
-      lo_page->p( n = `navButtonPress` v = client->_event_nav_app_leave( ) ).
-      lo_page->p( n = `showNavButton` v = client->check_app_prev_stack( ) ).
-      DATA(lo_form)    = lo_page->_( n = `SimpleForm` ns = `form` ).
-      lo_form->p( n = `title` v = `Form Title` ).
-      lo_form->p( n = `editable` v = abap_true ).
-      DATA(lo_content) = lo_form->_( n = `content` ns = `form` ).
+      DATA(lt_ns) = VALUE z2ui5_cl_util=>ty_t_name_value(
+          ( n = `displayBlock` v = `true` )
+          ( n = `height`       v = `100%` )
+          ( n = `xmlns`        v = `sap.m` )
+          ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` )
+          ( n = `xmlns:core`   v = `sap.ui.core` )
+          ( n = `xmlns:form`   v = `sap.ui.layout.form` ) ).
+      DATA(lt_page) = VALUE z2ui5_cl_util=>ty_t_name_value(
+          ( n = `title`          v = `abap2UI5 - First Example` )
+          ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
+          ( n = `showNavButton`  v = client->check_app_prev_stack( ) ) ).
+      DATA(lt_form) = VALUE z2ui5_cl_util=>ty_t_name_value(
+          ( n = `title`    v = `Form Title` )
+          ( n = `editable` v = abap_true ) ).
+      DATA(view) = z2ui5_cl_util_xml=>factory( ).
+      DATA(lo_content) = view->_( n = `View` ns = `mvc` p = lt_ns
+          )->_( `Shell`
+          )->_( n = `Page` p = lt_page
+          )->_( n = `SimpleForm` ns = `form` p = lt_form
+          )->_( n = `content` ns = `form` ).
       lo_content->__( n = `Title` a = `text` v = `Input` ).
       lo_content->__( n = `Label` a = `text` v = `quantity` ).
       lo_content->__( n = `Input` a = `value` v = client->_bind_edit( quantity ) ).
       lo_content->__( n = `Label` a = `text` v = `product` ).
       lo_content->__( n = `Input`
           p = VALUE #(
-                ( n = `value` v = product )
+                ( n = `value`   v = product )
                 ( n = `enabled` v = `false` ) ) ).
       lo_content->__( n = `Button`
           p = VALUE #(
-                ( n = `text` v = `post` )
+                ( n = `text`  v = `post` )
                 ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
       client->view_display( view->stringify( ) ).
     ELSEIF client->check_on_event( `BUTTON_POST` ).

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -33,11 +33,11 @@ CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
       lo_content->__( n = `Input` a = `value` v = client->_bind_edit( quantity ) ).
       lo_content->__( n = `Label` a = `text` v = `product` ).
       lo_content->__( n = `Input`
-          p = VALUE z2ui5_cl_util=>ty_t_name_value(
+          p = VALUE #(
                 ( n = `value` v = product )
                 ( n = `enabled` v = `false` ) ) ).
       lo_content->__( n = `Button`
-          p = VALUE z2ui5_cl_util=>ty_t_name_value(
+          p = VALUE #(
                 ( n = `text` v = `post` )
                 ( n = `press` v = client->_event( `BUTTON_POST` ) ) ) ).
       client->view_display( view->stringify( ) ).

--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -32,10 +32,10 @@ CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
           )->_( n = `Page` p = lt_page
           )->_( n = `SimpleForm` ns = `form` p = lt_form
           )->_( n = `content` ns = `form` ).
-      lo_content->__( n = `Title` a = `text` v = `Input` ).
-      lo_content->__( n = `Label` a = `text` v = `quantity` ).
-      lo_content->__( n = `Input` a = `value` v = client->_bind_edit( quantity ) ).
-      lo_content->__( n = `Label` a = `text` v = `product` ).
+      lo_content->__( n = `Title` a = `text` v = `Input`
+               )->__( n = `Label` a = `text` v = `quantity`
+               )->__( n = `Input` a = `value` v = client->_bind_edit( quantity )
+               )->__( n = `Label` a = `text` v = `product` ).
       lo_content->__( n = `Input`
           p = VALUE #(
                 ( n = `value`   v = product )

--- a/src/z2ui5_cl_demo_app_354.clas.xml
+++ b/src/z2ui5_cl_demo_app_354.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_354</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>First Example using Generic XML Builder</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary
This PR adds a new demo application (`z2ui5_cl_demo_app_354`) that demonstrates how to build UI5 views using the generic XML builder (`z2ui5_cl_util_xml`) instead of the typed fluent API. It also includes documentation updates explaining both view-building approaches.

## Key Changes
- **New demo app**: `z2ui5_cl_demo_app_354` — a "First Example" form with input fields and a button that showcases the generic XML builder pattern
  - Demonstrates building a `SimpleForm` with labels, inputs, and a button using direct XML element construction
  - Shows how to use namespaces (`form`, `mvc`) and bind data with `client->_bind_edit()`
  - Includes event handling for a POST button that displays a toast message
  
- **Documentation**: Updated `CLAUDE.md` with a new "Building Views" section that:
  - Explains the two approaches: typed fluent API vs. generic XML builder
  - Provides a side-by-side comparison of UI5 XML syntax and ABAP translation
  - Documents the key methods (`_()`, `__()`, `p()`) and their usage patterns
  - Clarifies namespace declaration rules and best practices

## Implementation Details
- The demo uses `z2ui5_cl_util_xml=>factory()` to build the view structure programmatically
- Demonstrates the difference between `_()` (navigate into child) and `__()` (stay at current level) methods
- Shows both single-attribute (`a = ... v = ...`) and multi-attribute (`p = VALUE #(...)`) syntax
- Includes proper namespace declarations for `sap.m`, `sap.ui.core.mvc`, and `sap.ui.layout.form`

https://claude.ai/code/session_017VDMwP9e3igacwHXBmiBaZ