### PR TITLE
Add navigation patterns documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,36 @@ ENDIF.
 | Info | `get()`, `get_event_arg()`, `get_app(id)` | Request/context data |
 | Constants | `cs_event`, `cs_view` | Predefined event IDs and view names |
 
+## Navigation
+
+### Back Navigation
+
+Always use `client->_event_nav_app_leave()` to bind the back button event directly in the view. This triggers navigation without a roundtrip to the ABAP backend:
+
+```abap
+METHOD view_display.
+  DATA(view) = z2ui5_cl_xml_view=>factory( ).
+  DATA(page) = view->page( title = `My App`
+                            shownavbutton = client->check_app_prev_stack( )
+                            navbuttonpress = client->_event_nav_app_leave( ) ).
+  " ...
+  client->view_display( view->stringify( ) ).
+ENDMETHOD.
+```
+
+Only use the manual pattern (handling `BACK` in `on_event`) when you need to do something with the app or client instance **before** navigating back — for example, writing data back to the previous app:
+
+```abap
+METHOD on_event.
+  CASE client->get( )-event.
+    WHEN `BACK`.
+      " interact with previous app instance first
+      CAST z2ui5_cl_app_parent( client->get_app_prev( ) )->set_result( ms_result ).
+      client->nav_app_leave( ).
+  ENDCASE.
+ENDMETHOD.
+```
+
 ## Building Views
 
 Views are XML strings passed to `client->view_display()`. There are two ways to build them:


### PR DESCRIPTION
## Summary
Added comprehensive documentation for back navigation patterns in z2ui5 applications, clarifying when to use direct event binding versus manual event handling.

## Changes
- **New Navigation section** with guidance on two back navigation approaches:
  - **Direct binding pattern**: Using `client->_event_nav_app_leave()` for simple back navigation without backend roundtrips
  - **Manual handling pattern**: Using `on_event` handler when app state needs to be updated before navigation (e.g., passing data back to parent app)

- **Code examples** for both patterns showing:
  - How to bind the back button event directly in the view
  - How to interact with the previous app instance before navigating away using `client->get_app_prev()`

## Details
The documentation clarifies the performance and use-case trade-offs between the two approaches, helping developers choose the appropriate pattern based on whether they need to perform operations on the app/client instance before leaving.

https://claude.ai/code/session_014x8o9NCeJevHbdLm3bZwVJ