### PR TITLE
Swap method naming convention for XML element creation

### DIFF
--- a/src/02/z2ui5_cl_demo_app_355.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_355.clas.abap
@@ -31,64 +31,64 @@ CLASS z2ui5_cl_demo_app_355 IMPLEMENTATION.
     ENDIF.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
                      ( n = `xmlns:core`   v = `sap.ui.core` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - InputListItem` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.InputListItem/sample/sap.m.sample.InputListItem` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Demo Kit` ) ) ).
 
-    DATA(list) = page->_( n = `List` a = `headerText` v = `Input` ).
+    DATA(list) = page->__( n = `List` a = `headerText` v = `Input` ).
 
-    list->_( n = `InputListItem` a = `label` v = `WLAN`
-       )->__( n = `Switch` a = `state` v = client->_bind_edit( wlan ) ).
+    list->__( n = `InputListItem` a = `label` v = `WLAN`
+       )->_( n = `Switch` a = `state` v = client->_bind_edit( wlan ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Flight Mode`
-       )->__( n = `CheckBox` a = `selected` v = client->_bind_edit( flight ) ).
+    list->__( n = `InputListItem` a = `label` v = `Flight Mode`
+       )->_( n = `CheckBox` a = `selected` v = client->_bind_edit( flight ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `High Performance`
-       )->__( n = `RadioButton`
+    list->__( n = `InputListItem` a = `label` v = `High Performance`
+       )->_( n = `RadioButton`
               p = VALUE #( ( n = `groupName` v = `GroupPerf` )
                            ( n = `selected`  v = client->_bind_edit( high_perf ) ) ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Battery Saving`
-       )->__( n = `RadioButton`
+    list->__( n = `InputListItem` a = `label` v = `Battery Saving`
+       )->_( n = `RadioButton`
               p = VALUE #( ( n = `groupName` v = `GroupPerf` )
                            ( n = `selected`  v = client->_bind_edit( battery ) ) ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Price (EUR)`
-       )->__( n = `Input`
+    list->__( n = `InputListItem` a = `label` v = `Price (EUR)`
+       )->_( n = `Input`
               p = VALUE #( ( n = `placeholder` v = `Price` )
                            ( n = `type`        v = `Number` )
                            ( n = `value`       v = client->_bind_edit( price ) ) ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Address`
-       )->__( n = `Input`
+    list->__( n = `InputListItem` a = `label` v = `Address`
+       )->_( n = `Input`
               p = VALUE #( ( n = `placeholder` v = `Address` )
                            ( n = `value`       v = client->_bind_edit( address ) ) ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Country`
-       )->_( n = `Select` a = `selectedKey` v = client->_bind_edit( country )
-           )->__( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `GR` ) ( n = `text` v = `Greece` ) )
-           )->__( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `MX` ) ( n = `text` v = `Mexico` ) )
-           )->__( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NO` ) ( n = `text` v = `Norway` ) )
-           )->__( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NZ` ) ( n = `text` v = `New Zealand` ) )
-           )->__( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NL` ) ( n = `text` v = `Netherlands` ) ) ).
+    list->__( n = `InputListItem` a = `label` v = `Country`
+       )->__( n = `Select` a = `selectedKey` v = client->_bind_edit( country )
+           )->_( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `GR` ) ( n = `text` v = `Greece` ) )
+           )->_( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `MX` ) ( n = `text` v = `Mexico` ) )
+           )->_( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NO` ) ( n = `text` v = `Norway` ) )
+           )->_( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NZ` ) ( n = `text` v = `New Zealand` ) )
+           )->_( n = `Item` ns = `core` p = VALUE #( ( n = `key` v = `NL` ) ( n = `text` v = `Netherlands` ) ) ).
 
-    list->_( n = `InputListItem` a = `label` v = `Volume`
-       )->_( n = `HBox` a = `justifyContent` v = `End`
-           )->__( n = `Slider`
+    list->__( n = `InputListItem` a = `label` v = `Volume`
+       )->__( n = `HBox` a = `justifyContent` v = `End`
+           )->_( n = `Slider`
                   p = VALUE #( ( n = `max`   v = `10` )
                                ( n = `min`   v = `0` )
                                ( n = `value` v = client->_bind_edit( volume ) )

--- a/src/02/z2ui5_cl_demo_app_356.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_356.clas.abap
@@ -16,46 +16,46 @@ CLASS z2ui5_cl_demo_app_356 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
                      ( n = `xmlns:l`      v = `sap.ui.layout` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - Label` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://ui5.sap.com/sdk/#/entity/sap.m.Label/sample/sap.m.sample.Label` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Demo Kit` ) ) ).
 
-    DATA(layout) = page->_( n = `VerticalLayout` ns = `l`
+    DATA(layout) = page->__( n = `VerticalLayout` ns = `l`
         p = VALUE #( ( n = `class` v = `sapUiContentPadding` )
                      ( n = `width` v = `100%` ) ) ).
 
-    layout->__( n = `Label`
+    layout->_( n = `Label`
                 p = VALUE #( ( n = `labelFor` v = `input-a` )
                              ( n = `text`     v = `Label A (required)` ) )
-           )->__( n = `Input`
+           )->_( n = `Input`
                   p = VALUE #( ( n = `id`       v = `input-a` )
                                ( n = `required` v = abap_true )
                                ( n = `value`    v = client->_bind_edit( input_a ) ) )
-           )->__( n = `Label`
+           )->_( n = `Label`
                   p = VALUE #( ( n = `design`   v = `Bold` )
                                ( n = `labelFor` v = `input-b` )
                                ( n = `text`     v = `Label B (bold)` ) )
-           )->__( n = `Input`
+           )->_( n = `Input`
                   p = VALUE #( ( n = `id`    v = `input-b` )
                                ( n = `value` v = client->_bind_edit( input_b ) ) )
-           )->__( n = `Label`
+           )->_( n = `Label`
                   p = VALUE #( ( n = `labelFor` v = `input-c` )
                                ( n = `text`     v = `Label C (normal)` ) )
-           )->__( n = `Input`
+           )->_( n = `Input`
                   p = VALUE #( ( n = `id`    v = `input-c` )
                                ( n = `value` v = client->_bind_edit( input_c ) ) ) ).
 

--- a/src/02/z2ui5_cl_demo_app_357.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_357.clas.abap
@@ -33,7 +33,7 @@ CLASS z2ui5_cl_demo_app_357 IMPLEMENTATION.
   METHOD view_display.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
@@ -41,56 +41,56 @@ CLASS z2ui5_cl_demo_app_357 IMPLEMENTATION.
                      ( n = `xmlns:l`      v = `sap.ui.layout` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - Controls` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://ui5.sap.com/sdk/#/controls` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Demo Kit` ) ) ).
 
-    DATA(panel) = page->_( n = `Panel`
+    DATA(panel) = page->__( n = `Panel`
         p = VALUE #( ( n = `accessibleRole`   v = `Region` )
                      ( n = `backgroundDesign` v = `Transparent` )
                      ( n = `class`            v = `sapUiNoContentPadding` ) ) ).
 
-    panel->_( `headerToolbar` )->_( `Toolbar`
-       )->__( n = `Title`
+    panel->__( `headerToolbar` )->__( `Toolbar`
+       )->_( n = `Title`
               p = VALUE #( ( n = `level`      v = `H1` )
                            ( n = `text`       v = `Featured Controls` )
                            ( n = `titleStyle` v = `H1` )
                            ( n = `width`      v = `100%` ) ) ).
 
-    DATA(bl)  = panel->_( n = `BlockLayout` ns = `l` ).
-    DATA(row) = bl->_( n = `BlockLayoutRow` ns = `l` ).
+    DATA(bl)  = panel->__( n = `BlockLayout` ns = `l` ).
+    DATA(row) = bl->__( n = `BlockLayoutRow` ns = `l` ).
     add_cell( io_row = row iv_shade = `ShadeA` iv_icon = `sap-icon://edit`         iv_title = `Input`   iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Input`   iv_descr = `User interaction` ).
     add_cell( io_row = row iv_shade = `ShadeB` iv_icon = `sap-icon://list`         iv_title = `Lists`   iv_href = `https://ui5.sap.com/sdk/#/controls/filter/List`    iv_descr = `Various list structures` ).
     add_cell( io_row = row iv_shade = `ShadeC` iv_icon = `sap-icon://table-view`   iv_title = `Tables`  iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Table`   iv_descr = `Simple or more powerful tables` ).
     add_cell( io_row = row iv_shade = `ShadeA` iv_icon = `sap-icon://popup-window` iv_title = `Pop-Ups` iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Popup`   iv_descr = `Dialogs and popovers` ).
 
-    row = bl->_( n = `BlockLayoutRow` ns = `l` ).
+    row = bl->__( n = `BlockLayoutRow` ns = `l` ).
     add_cell( io_row = row iv_shade = `ShadeB` iv_icon = `sap-icon://grid`          iv_title = `Tiles`    iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Tile`    iv_descr = `Tiles for e.g. texts, images or charts` ).
     add_cell( io_row = row iv_shade = `ShadeA` iv_icon = `sap-icon://message-popup` iv_title = `Messages` iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Message` iv_descr = `User notification` ).
     add_cell( io_row = row iv_shade = `ShadeB` iv_icon = `sap-icon://header`        iv_title = `Bars`     iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Bar`     iv_descr = `Toolbars and headers` ).
     add_cell( io_row = row iv_shade = `ShadeC` iv_icon = `sap-icon://tree`          iv_title = `Trees`    iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Tree`    iv_descr = `Hierarchical data representation` ).
 
-    panel = page->_( n = `Panel`
+    panel = page->__( n = `Panel`
         p = VALUE #( ( n = `accessibleRole`   v = `Region` )
                      ( n = `backgroundDesign` v = `Transparent` )
                      ( n = `class`            v = `sapUiNoContentPadding` ) ) ).
 
-    panel->_( `headerToolbar` )->_( `Toolbar`
-       )->__( n = `Title`
+    panel->__( `headerToolbar` )->__( `Toolbar`
+       )->_( n = `Title`
               p = VALUE #( ( n = `level`      v = `H1` )
                            ( n = `text`       v = `Layout & Pages` )
                            ( n = `titleStyle` v = `H1` )
                            ( n = `width`      v = `100%` ) ) ).
 
-    bl  = panel->_( n = `BlockLayout` ns = `l` ).
-    row = bl->_( n = `BlockLayoutRow` ns = `l` ).
+    bl  = panel->__( n = `BlockLayout` ns = `l` ).
+    row = bl->__( n = `BlockLayoutRow` ns = `l` ).
     add_cell( io_row = row iv_shade = `ShadeA` iv_icon = `sap-icon://write-new`          iv_title = `Object Page`            iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Object%20Page`             iv_descr = `Displaying, creating, or editing objects` ).
     add_cell( io_row = row iv_shade = `ShadeB` iv_icon = `sap-icon://chart-table-view`   iv_title = `Dynamic Page`           iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Dynamic%20Page`            iv_descr = `Page with title, header, and content area` ).
     add_cell( io_row = row iv_shade = `ShadeC` iv_icon = `sap-icon://screen-split-three` iv_title = `Flexible Column Layout` iv_href = `https://ui5.sap.com/sdk/#/controls/filter/Flexible%20Column%20Layout` iv_descr = `Page with up to 3 columns` ).
@@ -102,19 +102,19 @@ CLASS z2ui5_cl_demo_app_357 IMPLEMENTATION.
 
   METHOD add_cell.
 
-    DATA(cell) = io_row->_( n = `BlockLayoutCell` ns = `l`
+    DATA(cell) = io_row->__( n = `BlockLayoutCell` ns = `l`
         p = VALUE #( ( n = `backgroundColorSet`   v = `ColorSet10` )
                      ( n = `backgroundColorShade` v = iv_shade ) ) ).
-    DATA(vl) = cell->_( n = `VerticalLayout` ns = `l` ).
-    vl->__( n = `Icon` ns = `core`
+    DATA(vl) = cell->__( n = `VerticalLayout` ns = `l` ).
+    vl->_( n = `Icon` ns = `core`
             p = VALUE #( ( n = `class` v = `sapUiTinyMarginBottom` )
                          ( n = `size`  v = `2rem` )
                          ( n = `src`   v = iv_icon ) )
-      )->__( n = `Link`
+      )->_( n = `Link`
              p = VALUE #( ( n = `href`   v = iv_href )
                           ( n = `target` v = `_blank` )
                           ( n = `text`   v = iv_title ) )
-      )->__( n = `Text` a = `text` v = iv_descr ).
+      )->_( n = `Text` a = `text` v = iv_descr ).
 
   ENDMETHOD.
 

--- a/src/02/z2ui5_cl_demo_app_358.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_358.clas.abap
@@ -64,66 +64,66 @@ CLASS z2ui5_cl_demo_app_358 IMPLEMENTATION.
   METHOD view_display.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - Table` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://ui5.sap.com/sdk/#/entity/sap.m.Table/sample/sap.m.sample.Table` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Demo Kit` ) ) ).
 
-    DATA(tab) = page->_( n = `Table`
+    DATA(tab) = page->__( n = `Table`
         p = VALUE #( ( n = `inset` v = abap_false )
                      ( n = `items` v = client->_bind( mt_products ) ) ) ).
 
-    tab->_( `headerToolbar` )->_( `OverflowToolbar`
-       )->__( n = `Title`
+    tab->__( `headerToolbar` )->__( `OverflowToolbar`
+       )->_( n = `Title`
               p = VALUE #( ( n = `level` v = `H2` )
                            ( n = `text`  v = `Products` ) )
-       )->__( `ToolbarSpacer` ).
+       )->_( `ToolbarSpacer` ).
 
-    DATA(cols) = tab->_( `columns` ).
-    cols->_( n = `Column` a = `width` v = `12em`
-       )->__( n = `Text` a = `text` v = `Product` ).
-    cols->_( n = `Column`
+    DATA(cols) = tab->__( `columns` ).
+    cols->__( n = `Column` a = `width` v = `12em`
+       )->_( n = `Text` a = `text` v = `Product` ).
+    cols->__( n = `Column`
              p = VALUE #( ( n = `demandPopin`    v = abap_true )
                           ( n = `minScreenWidth` v = `Tablet` ) )
-       )->__( n = `Text` a = `text` v = `Supplier` ).
-    cols->_( n = `Column`
+       )->_( n = `Text` a = `text` v = `Supplier` ).
+    cols->__( n = `Column`
              p = VALUE #( ( n = `demandPopin`    v = abap_true )
                           ( n = `hAlign`         v = `End` )
                           ( n = `minScreenWidth` v = `Desktop` ) )
-       )->__( n = `Text` a = `text` v = `Dimensions` ).
-    cols->_( n = `Column`
+       )->_( n = `Text` a = `text` v = `Dimensions` ).
+    cols->__( n = `Column`
              p = VALUE #( ( n = `demandPopin`    v = abap_true )
                           ( n = `hAlign`         v = `Center` )
                           ( n = `minScreenWidth` v = `Desktop` ) )
-       )->__( n = `Text` a = `text` v = `Weight` ).
-    cols->_( n = `Column` a = `hAlign` v = `End`
-       )->__( n = `Text` a = `text` v = `Price` ).
+       )->_( n = `Text` a = `text` v = `Weight` ).
+    cols->__( n = `Column` a = `hAlign` v = `End`
+       )->_( n = `Text` a = `text` v = `Price` ).
 
-    DATA(cells) = tab->_( `items`
-        )->_( n = `ColumnListItem` a = `vAlign` v = `Middle`
-        )->_( `cells` ).
-    cells->__( n = `ObjectIdentifier`
+    DATA(cells) = tab->__( `items`
+        )->__( n = `ColumnListItem` a = `vAlign` v = `Middle`
+        )->__( `cells` ).
+    cells->_( n = `ObjectIdentifier`
                p = VALUE #( ( n = `text`  v = `{PRODUCT_ID}` )
                             ( n = `title` v = `{NAME}` ) ) ).
-    cells->__( n = `Text` a = `text` v = `{SUPPLIER_NAME}` ).
-    cells->__( n = `Text` a = `text` v = `{DIMENSIONS}` ).
-    cells->__( n = `ObjectNumber`
+    cells->_( n = `Text` a = `text` v = `{SUPPLIER_NAME}` ).
+    cells->_( n = `Text` a = `text` v = `{DIMENSIONS}` ).
+    cells->_( n = `ObjectNumber`
                p = VALUE #( ( n = `number` v = `{WEIGHT_MEASURE}` )
                             ( n = `state`  v = `{WEIGHT_STATE}` )
                             ( n = `unit`   v = `{WEIGHT_UNIT}` ) ) ).
-    cells->__( n = `ObjectNumber`
+    cells->_( n = `ObjectNumber`
                p = VALUE #( ( n = `number` v = `{PRICE}` )
                             ( n = `unit`   v = `{CURRENCY_CODE}` ) ) ).
 

--- a/src/02/z2ui5_cl_demo_app_359.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_359.clas.abap
@@ -54,63 +54,63 @@ CLASS z2ui5_cl_demo_app_359 IMPLEMENTATION.
     DATA(lv_vip_en) = `{= /vip/i.test($` && client->_bind( mv_search ) && `)}`.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
                      ( n = `xmlns:form`   v = `sap.ui.layout.form` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - Expression Binding` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://ui5.sap.com/sdk/#/topic/daf6852a04b44d118963968a1239d2c0` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Docs` ) ) ).
 
-    DATA(form) = page->_( n = `SimpleForm` ns = `form`
+    DATA(form) = page->__( n = `SimpleForm` ns = `form`
         p = VALUE #( ( n = `editable` v = abap_true )
                      ( n = `layout`   v = `ResponsiveGridLayout` )
                      ( n = `title`    v = `Expression Binding` ) ) ).
-    DATA(ct) = form->_( n = `content` ns = `form` ).
+    DATA(ct) = form->__( n = `content` ns = `form` ).
 
-    ct->__( n = `Title` a = `text` v = `String Concatenation` ).
-    ct->__( n = `Label`  a = `text` v = `First Name` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_first_name ) ).
-    ct->__( n = `Label`  a = `text` v = `Last Name` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_last_name ) ).
-    ct->__( n = `Label`  a = `text` v = `Result` ).
-    ct->__( n = `Text`   a = `text` v = lv_concat ).
+    ct->_( n = `Title` a = `text` v = `String Concatenation` ).
+    ct->_( n = `Label`  a = `text` v = `First Name` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_first_name ) ).
+    ct->_( n = `Label`  a = `text` v = `Last Name` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_last_name ) ).
+    ct->_( n = `Label`  a = `text` v = `Result` ).
+    ct->_( n = `Text`   a = `text` v = lv_concat ).
 
-    ct->__( n = `Title` a = `text` v = `Arithmetic` ).
-    ct->__( n = `Label`  a = `text` v = `Number A` ).
-    ct->__( n = `Input`
+    ct->_( n = `Title` a = `text` v = `Arithmetic` ).
+    ct->_( n = `Label`  a = `text` v = `Number A` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `type`  v = `Number` )
                          ( n = `value` v = client->_bind_edit( mv_num_a ) ) ) ).
-    ct->__( n = `Label`  a = `text` v = `Number B` ).
-    ct->__( n = `Input`
+    ct->_( n = `Label`  a = `text` v = `Number B` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `type`  v = `Number` )
                          ( n = `value` v = client->_bind_edit( mv_num_b ) ) ) ).
-    ct->__( n = `Label`  a = `text` v = `Math.max(A, B)` ).
-    ct->__( n = `Text`   a = `text` v = lv_max ).
+    ct->_( n = `Label`  a = `text` v = `Math.max(A, B)` ).
+    ct->_( n = `Text`   a = `text` v = lv_max ).
 
-    ct->__( n = `Title` a = `text` v = `Ternary Operator` ).
-    ct->__( n = `Label`  a = `text` v = `Amount` ).
-    ct->__( n = `Input`
+    ct->_( n = `Title` a = `text` v = `Ternary Operator` ).
+    ct->_( n = `Label`  a = `text` v = `Amount` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `type`  v = `Number` )
                          ( n = `value` v = client->_bind_edit( mv_amount ) ) ) ).
-    ct->__( n = `Label`  a = `text` v = `Sign` ).
-    ct->__( n = `Text`   a = `text` v = lv_sign ).
+    ct->_( n = `Label`  a = `text` v = `Sign` ).
+    ct->_( n = `Text`   a = `text` v = lv_sign ).
 
-    ct->__( n = `Title` a = `text` v = `Regular Expression` ).
-    ct->__( n = `Label`  a = `text` v = `Customer Name` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_search ) ).
-    ct->__( n = `Label`  a = `text` v = `VIP Action` ).
-    ct->__( n = `Button`
+    ct->_( n = `Title` a = `text` v = `Regular Expression` ).
+    ct->_( n = `Label`  a = `text` v = `Customer Name` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_search ) ).
+    ct->_( n = `Label`  a = `text` v = `VIP Action` ).
+    ct->_( n = `Button`
             p = VALUE #( ( n = `enabled` v = lv_vip_en )
                          ( n = `text`    v = `Grant VIP Access` )
                          ( n = `type`    v = `Emphasized` ) ) ).

--- a/src/02/z2ui5_cl_demo_app_360.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_360.clas.abap
@@ -60,59 +60,59 @@ CLASS z2ui5_cl_demo_app_360 IMPLEMENTATION.
         ` formatOptions: { source: { pattern: "yyyy-MM-dd" }, style: "long" } }`.
 
     DATA(view) = z2ui5_cl_util_xml=>factory( ).
-    DATA(root) = view->_( n = `View` ns = `mvc`
+    DATA(root) = view->__( n = `View` ns = `mvc`
         p = VALUE #( ( n = `displayBlock` v = abap_true )
                      ( n = `height`       v = `100%` )
                      ( n = `xmlns`        v = `sap.m` )
                      ( n = `xmlns:form`   v = `sap.ui.layout.form` )
                      ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
 
-    DATA(page) = root->_( `Shell` )->_( n = `Page`
+    DATA(page) = root->__( `Shell` )->__( n = `Page`
         p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
                      ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
                      ( n = `title`          v = `abap2UI5 - Formatter` ) ) ).
 
-    page->_( `headerContent`
-       )->__( n = `Link`
+    page->__( `headerContent`
+       )->_( n = `Link`
               p = VALUE #( ( n = `href`   v = `https://ui5.sap.com/sdk/#/topic/07e4b920f5734fd78fdaa236f26236d8` )
                            ( n = `target` v = `_blank` )
                            ( n = `text`   v = `UI5 Docs` ) ) ).
 
-    DATA(form) = page->_( n = `SimpleForm` ns = `form`
+    DATA(form) = page->__( n = `SimpleForm` ns = `form`
         p = VALUE #( ( n = `editable` v = abap_true )
                      ( n = `layout`   v = `ResponsiveGridLayout` )
                      ( n = `title`    v = `Formatter` ) ) ).
-    DATA(ct) = form->_( n = `content` ns = `form` ).
+    DATA(ct) = form->__( n = `content` ns = `form` ).
 
-    ct->__( n = `Title` a = `text` v = `Number` ).
-    ct->__( n = `Label`  a = `text` v = `Raw value` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_big_number ) ).
-    ct->__( n = `Label`  a = `text` v = `Float (grouped, 2 decimals)` ).
-    ct->__( n = `Input`
+    ct->_( n = `Title` a = `text` v = `Number` ).
+    ct->_( n = `Label`  a = `text` v = `Raw value` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_big_number ) ).
+    ct->_( n = `Label`  a = `text` v = `Float (grouped, 2 decimals)` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `enabled` v = abap_false )
                          ( n = `value`   v = lv_float_bind ) ) ).
-    ct->__( n = `Label`  a = `text` v = `Raw integer` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_integer ) ).
-    ct->__( n = `Label`  a = `text` v = `Integer (formatted)` ).
-    ct->__( n = `Input`
+    ct->_( n = `Label`  a = `text` v = `Raw integer` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_integer ) ).
+    ct->_( n = `Label`  a = `text` v = `Integer (formatted)` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `enabled` v = abap_false )
                          ( n = `value`   v = lv_int_bind ) ) ).
 
-    ct->__( n = `Title` a = `text` v = `Currency` ).
-    ct->__( n = `Label`  a = `text` v = `Price` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_price ) ).
-    ct->__( n = `Label`  a = `text` v = `Currency code` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_currency ) ).
-    ct->__( n = `Label`  a = `text` v = `Formatted (Currency type)` ).
-    ct->__( n = `Input`
+    ct->_( n = `Title` a = `text` v = `Currency` ).
+    ct->_( n = `Label`  a = `text` v = `Price` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_price ) ).
+    ct->_( n = `Label`  a = `text` v = `Currency code` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_currency ) ).
+    ct->_( n = `Label`  a = `text` v = `Formatted (Currency type)` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `enabled` v = abap_false )
                          ( n = `value`   v = lv_curr_bind ) ) ).
 
-    ct->__( n = `Title` a = `text` v = `Date` ).
-    ct->__( n = `Label`  a = `text` v = `Raw date (yyyy-MM-dd)` ).
-    ct->__( n = `Input`  a = `value` v = client->_bind_edit( mv_date ) ).
-    ct->__( n = `Label`  a = `text` v = `Formatted (long style)` ).
-    ct->__( n = `Input`
+    ct->_( n = `Title` a = `text` v = `Date` ).
+    ct->_( n = `Label`  a = `text` v = `Raw date (yyyy-MM-dd)` ).
+    ct->_( n = `Input`  a = `value` v = client->_bind_edit( mv_date ) ).
+    ct->_( n = `Label`  a = `text` v = `Formatted (long style)` ).
+    ct->_( n = `Input`
             p = VALUE #( ( n = `enabled` v = abap_false )
                          ( n = `value`   v = lv_date_bind ) ) ).
 


### PR DESCRIPTION
## Summary
This PR swaps the naming convention for XML element creation methods in the `z2ui5_cl_util_xml` utility class. The single underscore method `_()` and double underscore method `__()` have been exchanged across multiple demo applications.

## Changes Made
- **Method naming swap**: Inverted the usage of `_()` and `__()` methods throughout 6 demo application classes:
  - `z2ui5_cl_demo_app_355.clas.abap`
  - `z2ui5_cl_demo_app_356.clas.abap`
  - `z2ui5_cl_demo_app_357.clas.abap`
  - `z2ui5_cl_demo_app_358.clas.abap`
  - `z2ui5_cl_demo_app_359.clas.abap`
  - `z2ui5_cl_demo_app_360.clas.abap`

- **Pattern**: All instances where `->_()` was called are now `->__()`, and all instances where `->__()` was called are now `->_()`

## Implementation Details
- This appears to be a refactoring to align method naming with a new convention or API design
- The change is systematic and consistent across all affected files
- No functional logic changes; only method names are swapped
- All method parameters, attributes, and chaining patterns remain identical

https://claude.ai/code/session_01MuuStBKcx3Wcz2NZX1L5yC