### PR TITLE
Enforce consistent code formatting and blank line rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
   - Max 1 consecutive blank line inside the definition block.
   - Add one blank line between groups of different declaration types (e.g. between `INTERFACES` and `DATA`, or `DATA` and `METHODS`).
 - **Blank lines — outside methods** (`EMPTY_LINES_OUTSIDE_METHODS`):
-  - Exactly 1 blank line between `ENDCLASS.` and the next `CLASS … IMPLEMENTATION.` (i.e. between the definition and the implementation block).
-  - Exactly 1 blank line between two `METHOD … ENDMETHOD.` blocks.
+  - Exactly 2 blank lines between `ENDCLASS.` and the next `CLASS … IMPLEMENTATION.` (i.e. between the definition and the implementation block).
+  - Exactly 2 blank lines between two `METHOD … ENDMETHOD.` blocks.
   - Exactly 2 blank lines between two top-level class blocks.
 - **Blank lines — inside methods** (`EMPTY_LINES_WITHIN_METHODS`):
   - Always add exactly 1 blank line at the very start of a method body (after `METHOD`).
@@ -91,12 +91,14 @@ Always use `client->_event_nav_app_leave()` to bind the back button event direct
 
 ```abap
 METHOD view_display.
+
   DATA(view) = z2ui5_cl_xml_view=>factory( ).
   DATA(page) = view->page( title = `My App`
                             shownavbutton = client->check_app_prev_stack( )
                             navbuttonpress = client->_event_nav_app_leave( ) ).
   " ...
   client->view_display( view->stringify( ) ).
+
 ENDMETHOD.
 ```
 
@@ -104,12 +106,14 @@ Only use the manual pattern (handling `BACK` in `on_event`) when you need to do 
 
 ```abap
 METHOD on_event.
+
   CASE client->get( )-event.
     WHEN `BACK`.
       " interact with previous app instance first
       CAST z2ui5_cl_app_parent( client->get_app_prev( ) )->set_result( ms_result ).
       client->nav_app_leave( ).
   ENDCASE.
+
 ENDMETHOD.
 ```
 
@@ -183,8 +187,11 @@ CLASS z2ui5_cl_app_xxx DEFINITION PUBLIC CREATE PUBLIC.
   PRIVATE SECTION.
 ENDCLASS.
 
+
 CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
+
   METHOD z2ui5_if_app~main.
+
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
@@ -193,36 +200,66 @@ CLASS z2ui5_cl_app_xxx IMPLEMENTATION.
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.
+
   ENDMETHOD.
+
+
   METHOD on_init.
+
     data_read( ).
     view_display( ).
+
   ENDMETHOD.
+
+
   METHOD on_navigation.
+
     data_read( ).
     client->view_model_update( ).
+
   ENDMETHOD.
+
+
   METHOD on_event.
+
     CASE client->get( )-event.
       WHEN `SAVE`.
         on_event_save( ).
       WHEN `BACK`.
         client->nav_app_leave( ).
     ENDCASE.
+
   ENDMETHOD.
+
+
   METHOD on_event_save.
+
     data_update( ).
+
   ENDMETHOD.
+
+
   METHOD view_display.
+
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
     " ...
     client->view_display( view->stringify( ) ).
+
   ENDMETHOD.
+
+
   METHOD data_read.
+
     " SELECT ...
+
   ENDMETHOD.
+
+
   METHOD data_update.
+
     " INSERT / UPDATE / DELETE ...
+
   ENDMETHOD.
+
 ENDCLASS.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,40 @@ Views are XML strings passed to `client->view_display()`. There are two ways to 
 ### 1. `z2ui5_cl_xml_view` — typed fluent API
 Pre-built methods for common UI5 controls (`shell`, `page`, `simple_form`, `input`, `button`, etc.). Use this for standard layouts.
 
+#### View structure and indentation
+
+Always build the view in `view_display` and call `client->view_display( view->stringify( ) )` as a **standalone statement at the end** — never nested inside the chain.
+
+Indent the fluent chain to reflect the XML hierarchy:
+- Each method that **navigates into a child element** (returns a child node) is indented **4 spaces deeper** than its parent call.
+- Methods that **add a sibling** within the same container (and return the container) stay at the **same indentation level**.
+
+```abap
+METHOD view_display.
+
+  DATA(view) = z2ui5_cl_xml_view=>factory( ).
+  view->shell(
+      )->page(
+          title          = `My App`
+          navbuttonpress = client->_event_nav_app_leave( )
+          shownavbutton  = client->check_app_prev_stack( )
+          )->simple_form( title = `Form Title` editable = abap_true
+              )->content( `form`
+              )->label( `Quantity`
+              )->input( client->_bind_edit( quantity )
+              )->label( `Product`
+              )->input( value = product enabled = abap_false
+              )->button(
+                  text  = `Post`
+                  press = client->_event( `POST` ) ).
+  client->view_display( view->stringify( ) ).
+
+ENDMETHOD.
+```
+
+The hierarchy above is: `shell` → `page` → `simple_form` → `content` → (leaf elements).
+`label`, `input`, `button` are siblings inside `content`, so they stay at the same indent level as `)->content(`.
+
 ### 2. `z2ui5_cl_util_xml` — generic XML builder
 Builds any XML structure directly from element names, namespaces and attributes. **Look up the control in the [UI5 API Reference](https://ui5.sap.com/#/api) and translate 1:1 to ABAP** — no wrapper, no abstraction layer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,9 @@ abap2UI5 Samples - Collection of demo apps for the abap2UI5 framework.
   - Exactly 1 blank line between two `METHOD … ENDMETHOD.` blocks.
   - Exactly 2 blank lines between two top-level class blocks.
 - **Blank lines — inside methods** (`EMPTY_LINES_WITHIN_METHODS`):
+  - Always add exactly 1 blank line at the very start of a method body (after `METHOD`).
+  - Always add exactly 1 blank line at the very end of a method body (before `ENDMETHOD`).
   - Max 1 consecutive blank line inside a method body.
-  - At most 1 blank line at the very start of a method body (after `METHOD`).
-  - At most 1 blank line at the very end of a method body (before `ENDMETHOD`).
-  - One blank line above the first executable statement is allowed.
 - Always run `abaplint` after every change. It must report 0 issues before committing.
 - Before starting app development, read all active rules in `abaplint.jsonc` and follow them throughout.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,22 @@ Indent the fluent chain to reflect the XML hierarchy:
 - Each method that **navigates into a child element** (returns a child node) is indented **4 spaces deeper** than its parent call.
 - Methods that **add a sibling** within the same container (and return the container) stay at the **same indentation level**.
 
+#### Parameter formatting
+
+- **Single parameter**: write inline — `)->label( `Quantity` )` or `)->input( client->_bind_edit( qty ) )`.
+- **More than one parameter**: always split across multiple lines — one parameter per line, aligned below the opening `(`, closing `)` on its own line:
+
+```abap
+)->input(
+    value   = product
+    enabled = abap_false
+)->button(
+    text  = `Post`
+    press = client->_event( `POST` ) ).
+```
+
+Never put two or more named parameters on the same line.
+
 ```abap
 METHOD view_display.
 
@@ -141,12 +157,16 @@ METHOD view_display.
           title          = `My App`
           navbuttonpress = client->_event_nav_app_leave( )
           shownavbutton  = client->check_app_prev_stack( )
-          )->simple_form( title = `Form Title` editable = abap_true
+          )->simple_form(
+              title    = `Form Title`
+              editable = abap_true
               )->content( `form`
               )->label( `Quantity`
               )->input( client->_bind_edit( quantity )
               )->label( `Product`
-              )->input( value = product enabled = abap_false
+              )->input(
+                  value   = product
+                  enabled = abap_false
               )->button(
                   text  = `Post`
                   press = client->_event( `POST` ) ).

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -53,22 +53,22 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
   METHOD view_display.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    client->view_display( view->shell(
-           )->page(
-                   title          = `abap2UI5 - First Example`
-                   navbuttonpress = client->_event_nav_app_leave( )
-                   shownavbutton  = client->check_app_prev_stack( )
-        )->simple_form( title = `Form Title` editable = abap_true
-                   )->content( `form`
-                       )->title( `Input`
-                       )->label( `quantity`
-                       )->input( client->_bind_edit( quantity )
-                       )->label( `product`
-                       )->input( value = product enabled = abap_false
-                       )->button(
-                           text  = `post`
-                           press = client->_event( `BUTTON_POST` )
-            )->stringify( ) ).
+    view->shell(
+    )->page(
+        title          = `abap2UI5 - First Example`
+        navbuttonpress = client->_event_nav_app_leave( )
+        shownavbutton  = client->check_app_prev_stack( )
+    )->simple_form( title = `Form Title` editable = abap_true
+    )->content( `form`
+    )->title( `Input`
+    )->label( `quantity`
+    )->input( client->_bind_edit( quantity )
+    )->label( `product`
+    )->input( value = product enabled = abap_false
+    )->button(
+        text  = `post`
+        press = client->_event( `BUTTON_POST` ) ).
+    client->view_display( view->stringify( ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -54,20 +54,20 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
     view->shell(
-    )->page(
-        title          = `abap2UI5 - First Example`
-        navbuttonpress = client->_event_nav_app_leave( )
-        shownavbutton  = client->check_app_prev_stack( )
-    )->simple_form( title = `Form Title` editable = abap_true
-    )->content( `form`
-    )->title( `Input`
-    )->label( `quantity`
-    )->input( client->_bind_edit( quantity )
-    )->label( `product`
-    )->input( value = product enabled = abap_false
-    )->button(
-        text  = `post`
-        press = client->_event( `BUTTON_POST` ) ).
+        )->page(
+            title          = `abap2UI5 - First Example`
+            navbuttonpress = client->_event_nav_app_leave( )
+            shownavbutton  = client->check_app_prev_stack( )
+            )->simple_form( title = `Form Title` editable = abap_true
+                )->content( `form`
+                )->title( `Input`
+                )->label( `quantity`
+                )->input( client->_bind_edit( quantity )
+                )->label( `product`
+                )->input( value = product enabled = abap_false
+                )->button(
+                    text  = `post`
+                    press = client->_event( `BUTTON_POST` ) ).
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -16,6 +16,7 @@ CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC CREATE PUBLIC.
   PRIVATE SECTION.
 ENDCLASS.
 
+
 CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
@@ -29,6 +30,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
   ENDMETHOD.
 
+
   METHOD on_init.
 
     product  = `products`.
@@ -36,6 +38,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
     view_display( ).
 
   ENDMETHOD.
+
 
   METHOD on_event.
 
@@ -45,6 +48,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
 
   METHOD view_display.
 

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -58,13 +58,17 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
             title          = `abap2UI5 - First Example`
             navbuttonpress = client->_event_nav_app_leave( )
             shownavbutton  = client->check_app_prev_stack( )
-            )->simple_form( title = `Form Title` editable = abap_true
+            )->simple_form(
+                title    = `Form Title`
+                editable = abap_true
                 )->content( `form`
                 )->title( `Input`
                 )->label( `quantity`
                 )->input( client->_bind_edit( quantity )
                 )->label( `product`
-                )->input( value = product enabled = abap_false
+                )->input(
+                    value   = product
+                    enabled = abap_false
                 )->button(
                     text  = `post`
                     press = client->_event( `BUTTON_POST` ) ).

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -1,84 +1,63 @@
 CLASS z2ui5_cl_demo_app_001 DEFINITION PUBLIC CREATE PUBLIC.
 
   PUBLIC SECTION.
-
     INTERFACES z2ui5_if_app.
 
     DATA product  TYPE string.
     DATA quantity TYPE string.
 
-
   PROTECTED SECTION.
-
     DATA client TYPE REF TO z2ui5_if_client.
 
-    METHODS z2ui5_set_data.
-
-    METHODS display_view
-      IMPORTING
-        client TYPE REF TO z2ui5_if_client.
-    METHODS on_event
-      IMPORTING
-        client TYPE REF TO z2ui5_if_client.
+    METHODS on_init.
+    METHODS on_event.
+    METHODS view_display.
 
   PRIVATE SECTION.
 ENDCLASS.
 
-
-
 CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
-
     me->client = client.
-
-
     IF client->check_on_init( ).
-      display_view( client ).
-      z2ui5_set_data( ).
+      on_init( ).
+    ELSEIF client->check_on_event( ).
+      on_event( ).
     ENDIF.
-
-    on_event( client ).
-
   ENDMETHOD.
 
+  METHOD on_init.
+    product  = `products`.
+    quantity = `500`.
+    view_display( ).
+  ENDMETHOD.
 
-  METHOD display_view.
+  METHOD on_event.
+    CASE client->get( )-event.
+      WHEN `BUTTON_POST`.
+        client->message_toast_display( |{ product } { quantity } - send to the server| ).
+    ENDCASE.
+  ENDMETHOD.
 
+  METHOD view_display.
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
     client->view_display( view->shell(
            )->page(
-                   title          = 'abap2UI5 - First Example'
+                   title          = `abap2UI5 - First Example`
                    navbuttonpress = client->_event_nav_app_leave( )
                    shownavbutton  = client->check_app_prev_stack( )
-        )->simple_form( title = 'Form Title' editable = abap_true
-                   )->content( 'form'
-                       )->title( 'Input'
-                       )->label( 'quantity'
+        )->simple_form( title = `Form Title` editable = abap_true
+                   )->content( `form`
+                       )->title( `Input`
+                       )->label( `quantity`
                        )->input( client->_bind_edit( quantity )
                        )->label( `product`
                        )->input( value = product enabled = abap_false
                        )->button(
-                           text  = 'post'
-                           press = client->_event( 'BUTTON_POST' )
+                           text  = `post`
+                           press = client->_event( `BUTTON_POST` )
             )->stringify( ) ).
-
   ENDMETHOD.
 
-
-  METHOD on_event.
-
-    IF client->check_on_event( 'BUTTON_POST' ).
-      client->message_toast_display( |{ product } { quantity } - send to the server| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD z2ui5_set_data.
-
-    product  = 'products'.
-    quantity = '500'.
-
-  ENDMETHOD.
 ENDCLASS.

--- a/src/z2ui5_cl_demo_app_001.clas.abap
+++ b/src/z2ui5_cl_demo_app_001.clas.abap
@@ -19,28 +19,35 @@ ENDCLASS.
 CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
+
     me->client = client.
     IF client->check_on_init( ).
       on_init( ).
     ELSEIF client->check_on_event( ).
       on_event( ).
     ENDIF.
+
   ENDMETHOD.
 
   METHOD on_init.
+
     product  = `products`.
     quantity = `500`.
     view_display( ).
+
   ENDMETHOD.
 
   METHOD on_event.
+
     CASE client->get( )-event.
       WHEN `BUTTON_POST`.
         client->message_toast_display( |{ product } { quantity } - send to the server| ).
     ENDCASE.
+
   ENDMETHOD.
 
   METHOD view_display.
+
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
     client->view_display( view->shell(
            )->page(
@@ -58,6 +65,7 @@ CLASS z2ui5_cl_demo_app_001 IMPLEMENTATION.
                            text  = `post`
                            press = client->_event( `BUTTON_POST` )
             )->stringify( ) ).
+
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
## Summary
Updated coding standards documentation and refactored demo app to enforce consistent blank line spacing, method organization, and view building patterns across the codebase.

## Key Changes

**Documentation Updates (CLAUDE.md):**
- Changed blank line requirements between class definition/implementation and between methods from 1 to **exactly 2 blank lines**
- Clarified blank line rules inside methods: now **require exactly 1 blank line** at the start and end of method bodies (previously "at most 1")
- Added comprehensive view building guidelines for `z2ui5_cl_xml_view`:
  - Indentation rules reflecting XML hierarchy (4 spaces per nesting level)
  - Parameter formatting standards (single parameter inline, multiple parameters split across lines)
  - Complete example demonstrating proper structure and alignment
- Updated class template example to reflect new blank line spacing rules

**Code Refactoring (z2ui5_cl_demo_app_001.clas.abap):**
- Reorganized method structure to follow standard pattern: `on_init()`, `on_event()`, `view_display()`
- Removed unnecessary helper methods (`z2ui5_set_data`, `display_view`) and consolidated logic
- Applied consistent 2-blank-line spacing between methods and class blocks
- Applied consistent 1-blank-line spacing at start/end of all method bodies
- Refactored `view_display()` to build view separately from `client->view_display()` call
- Reformatted fluent chain with proper indentation reflecting XML hierarchy
- Split multi-parameter method calls across multiple lines with aligned parameters
- Standardized string literals to backticks (`` ` ``) for consistency
- Simplified event handling using `CASE` statement instead of conditional checks

## Implementation Details
The refactored demo app now serves as a reference implementation of the updated coding standards, demonstrating proper method organization, blank line spacing, and fluent API usage patterns for building UI5 views.

https://claude.ai/code/session_01GVzJXJkvA771wvS9SghJUd