### PR TITLE
Rename demo app class from Z2UI5_CL_DEMO_APP_351 to Z2UI5_CL_DEMO_APP_S_06

### DIFF
--- a/src/00/z2ui5_cl_demo_app_s_06.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_06.clas.abap
@@ -1,4 +1,4 @@
-CLASS z2ui5_cl_demo_app_351 DEFINITION
+CLASS z2ui5_cl_demo_app_s_06 DEFINITION
   PUBLIC
   CREATE PUBLIC .
 
@@ -10,7 +10,7 @@ ENDCLASS.
 
 
 
-CLASS Z2UI5_CL_DEMO_APP_351 IMPLEMENTATION.
+CLASS z2ui5_cl_demo_app_s_06 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
     client->nav_app_call( NEW zcl_2ui5_start( ) ).

--- a/src/00/z2ui5_cl_demo_app_s_06.clas.locals_imp.abap
+++ b/src/00/z2ui5_cl_demo_app_s_06.clas.locals_imp.abap
@@ -1,7 +1,7 @@
 CLASS zcl_2ui5_start DEFINITION DEFERRED.
 CLASS zcl_2ui5_lock DEFINITION DEFERRED.
 
-CLASS zcl_2ui5_start DEFINITION INHERITING FROM z2ui5_cl_demo_app_351.
+CLASS zcl_2ui5_start DEFINITION INHERITING FROM z2ui5_cl_demo_app_s_06.
   PUBLIC SECTION.
     DATA text TYPE string VALUE 'call booking mask'.
     METHODS z2ui5_if_app~main                       REDEFINITION.
@@ -9,7 +9,7 @@ CLASS zcl_2ui5_start DEFINITION INHERITING FROM z2ui5_cl_demo_app_351.
   PRIVATE SECTION.
 ENDCLASS.
 
-CLASS zcl_2ui5_lock DEFINITION INHERITING FROM z2ui5_cl_demo_app_351.
+CLASS zcl_2ui5_lock DEFINITION INHERITING FROM z2ui5_cl_demo_app_s_06.
   PUBLIC SECTION.
     DATA varkey TYPE char120.
     METHODS z2ui5_if_app~main                       REDEFINITION.

--- a/src/00/z2ui5_cl_demo_app_s_06.clas.xml
+++ b/src/00/z2ui5_cl_demo_app_s_06.clas.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>Z2UI5_CL_DEMO_APP_351</CLSNAME>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_S_06</CLSNAME>
     <LANGU>E</LANGU>
     <DESCRIPT>Navigation with app state change v2</DESCRIPT>
     <STATE>1</STATE>


### PR DESCRIPTION
## Summary
Refactored the demo application class to use a more descriptive naming convention that aligns with the module structure (S_06 likely indicating "Section 06").

## Key Changes
- Renamed main class from `Z2UI5_CL_DEMO_APP_351` to `Z2UI5_CL_DEMO_APP_S_06`
- Updated all class definition and implementation references to use the new name
- Updated parent class references in local implementation classes (`zcl_2ui5_start` and `zcl_2ui5_lock`)
- Updated class metadata (XML descriptor) to reflect the new class name

## Details
This is a straightforward class rename that improves code readability by replacing a numeric identifier (351) with a semantic identifier (S_06) that better describes the demo's purpose or section. All references throughout the class hierarchy have been consistently updated to maintain functionality.

https://claude.ai/code/session_01VcD2aVEXzUygYroWL5BG1c