### PR TITLE
fix: add data-state guard to init check in samples 339 and 342

### DIFF
--- a/src/z2ui5_cl_demo_app_339.clas.abap
+++ b/src/z2ui5_cl_demo_app_339.clas.abap
@@ -158,7 +158,7 @@ CLASS z2ui5_cl_demo_app_339 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR mt_table IS INITIAL.
 
       get_data( ).
 

--- a/src/z2ui5_cl_demo_app_342.clas.abap
+++ b/src/z2ui5_cl_demo_app_342.clas.abap
@@ -159,7 +159,7 @@ CLASS z2ui5_cl_demo_app_342 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
-    IF client->check_on_init( ).
+    IF client->check_on_init( ) OR mt_data IS INITIAL.
 
       get_data( ).
 


### PR DESCRIPTION
client->check_on_init() checks the root app's check_initialized flag, not the sub-app's own state. When sample 338 dynamically creates a new sub-app instance after a tab switch, the root app (338) is already initialized so check_on_init() returns false — causing get_data() and render_main() to be skipped on a fresh instance, leaving mt_table/mt_data as NULL and producing a NULL-dereference error.

Add `OR mt_table IS INITIAL` / `OR mt_data IS INITIAL` so that freshly created sub-app instances always run their initialization regardless of the root app's state, while already-initialized (deserialized) instances correctly skip it on subsequent roundtrips.

https://claude.ai/code/session_013QHAz9q9WnLNYngajxtFwD