### PR TITLE
Add System Logout demo app (361)

### DIFF
--- a/src/02/z2ui5_cl_demo_app_361.clas.abap
+++ b/src/02/z2ui5_cl_demo_app_361.clas.abap
@@ -1,0 +1,55 @@
+CLASS z2ui5_cl_demo_app_361 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_demo_app_361 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    IF client->check_on_init( ).
+
+      DATA(view) = z2ui5_cl_util_xml=>factory( ).
+      DATA(root) = view->__( n = `View` ns = `mvc`
+          p = VALUE #( ( n = `displayBlock` v = abap_true )
+                       ( n = `height`       v = `100%` )
+                       ( n = `xmlns`        v = `sap.m` )
+                       ( n = `xmlns:mvc`    v = `sap.ui.core.mvc` ) ) ).
+
+      DATA(page) = root->__( `Shell`
+         )->__( n = `Page`
+                p = VALUE #( ( n = `navButtonPress` v = client->_event_nav_app_leave( ) )
+                             ( n = `showNavButton`  v = client->check_app_prev_stack( ) )
+                             ( n = `title`          v = `abap2UI5 - System Logout` ) ) ).
+
+      page->__( `headerContent`
+         )->_( n = `Button`
+               p = VALUE #( ( n = `icon`    v = `sap-icon://log` )
+                            ( n = `text`    v = `Logout` )
+                            ( n = `tooltip` v = `Sign out of the current session` )
+                            ( n = `press`   v = client->_event_client( client->cs_event-system_logout ) ) ) ).
+
+      page->__( n = `MessageStrip`
+             p = VALUE #( ( n = `class`    v = `sapUiMediumMargin` )
+                          ( n = `showIcon` v = abap_true )
+                          ( n = `text`     v = `This demo shows the new system logout event. Pressing the button below triggers SYSTEM_LOGOUT on the client. Inside a Fiori Launchpad the shell container handles the sign-out; otherwise the app navigates to the ICF logoff endpoint.` )
+                          ( n = `type`     v = `Information` ) )
+         )->_( n = `Button`
+               p = VALUE #( ( n = `class` v = `sapUiSmallMargin` )
+                            ( n = `icon`  v = `sap-icon://log` )
+                            ( n = `text`  v = `Logout now` )
+                            ( n = `type`  v = `Reject` )
+                            ( n = `press` v = client->_event_client( client->cs_event-system_logout ) ) ) ).
+
+      client->view_display( view->stringify( ) ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/02/z2ui5_cl_demo_app_361.clas.xml
+++ b/src/02/z2ui5_cl_demo_app_361.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_361</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>more - System Logout</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/z2ui5_cl_demo_app_000.clas.abap
+++ b/src/z2ui5_cl_demo_app_000.clas.abap
@@ -238,6 +238,12 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
                          mode      = `LineMode`
                          class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
 
+    panel->generic_tile( header    = `System Logout`
+                         subheader = `Trigger SYSTEM_LOGOUT client event`
+                         press     = client->_event( `z2ui5_cl_demo_app_361` )
+                         mode      = `LineMode`
+                         class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
+
     panel = page->panel( expandable = abap_false
                          expanded   = abap_true
                          headertext = `Messages` ).


### PR DESCRIPTION
## Summary
This PR adds a new demo application that showcases the system logout functionality in abap2UI5. The demo allows users to trigger a SYSTEM_LOGOUT client event, which handles sign-out either through a Fiori Launchpad shell container or by navigating to the ICF logoff endpoint.

## Key Changes
- **New Demo App (z2ui5_cl_demo_app_361)**: Created a new application class that demonstrates the system logout feature
  - Implements the z2ui5_if_app interface
  - Displays an informational message explaining the logout functionality
  - Provides two logout buttons with consistent styling and icons
  - Uses the `client->_event_client( client->cs_event-system_logout )` event to trigger logout
  
- **Updated Demo Navigation (z2ui5_cl_demo_app_000)**: Added a new tile in the main demo app menu
  - Links to the new System Logout demo
  - Includes descriptive header and subheader text
  - Maintains consistent styling with other demo tiles

## Implementation Details
- The logout UI is built using the z2ui5_cl_util_xml utility for XML/UI5 view generation
- The page includes a MessageStrip component with an Information type to educate users about the feature
- Two action buttons are provided: one in the header and one in the message strip, both triggering the same SYSTEM_LOGOUT event
- The implementation follows the existing abap2UI5 patterns and conventions

https://claude.ai/code/session_01HNzSniBLv2WAPqxL6KEajy