### PR TITLE
Add UploadSet custom control demo app

### DIFF
--- a/src/z2ui5_cl_demo_app_354.clas.abap
+++ b/src/z2ui5_cl_demo_app_354.clas.abap
@@ -1,0 +1,78 @@
+CLASS z2ui5_cl_demo_app_354 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    TYPES:
+      BEGIN OF ty_s_file,
+        filename  TYPE string,
+        mediatype TYPE string,
+        size      TYPE string,
+        data      TYPE string,
+      END OF ty_s_file.
+    DATA t_files TYPE STANDARD TABLE OF ty_s_file WITH EMPTY KEY.
+
+    DATA filedata  TYPE string.
+    DATA filename  TYPE string.
+    DATA mediatype TYPE string.
+    DATA filesize  TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_demo_app_354 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    IF client->check_on_init( ).
+
+      DATA(view) = z2ui5_cl_xml_view=>factory( ).
+      DATA(page) = view->shell( )->page(
+          title          = `abap2UI5 - UploadSet Custom Control`
+          navbuttonpress = client->_event_nav_app_leave( )
+          shownavbutton  = client->check_app_prev_stack( )
+          class          = `sapUiContentPadding` ).
+
+      page->_z2ui5( )->uploadset_ext(
+          uploadsetid = `myUploadSet`
+          filedata    = client->_bind_edit( filedata )
+          filename    = client->_bind_edit( filename )
+          mediatype   = client->_bind_edit( mediatype )
+          filesize    = client->_bind_edit( filesize )
+          change      = client->_event( `FILE_ADDED` ) ).
+
+      page->upload_set(
+              id            = `myUploadSet`
+              instantupload = abap_true
+              showicons     = abap_true
+              uploadenabled = abap_true
+              mode          = `MultiSelect`
+              items         = client->_bind_edit( t_files )
+          )->items( `upload`
+              )->upload_set_item(
+                  filename  = `{FILENAME}`
+                  mediatype = `{MEDIATYPE}` ).
+
+      client->view_display( view->stringify( ) ).
+
+    ELSEIF client->check_on_event( `FILE_ADDED` ).
+
+      INSERT VALUE #( filename  = filename
+                      mediatype = mediatype
+                      size      = filesize
+                      data      = filedata ) INTO TABLE t_files.
+
+      filedata  = ``.
+      filename  = ``.
+      mediatype = ``.
+      filesize  = ``.
+
+      client->view_model_update( ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z2ui5_cl_demo_app_354.clas.xml
+++ b/src/z2ui5_cl_demo_app_354.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_354</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>UploadSet Custom Control Demo</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary

Add a new demo app (`z2ui5_cl_demo_app_354`) showcasing the UploadSet custom control functionality in abap2UI5, demonstrating file upload handling with metadata capture.

## Changes

- **New demo app class**: `z2ui5_cl_demo_app_354`
  - Implements `z2ui5_if_app` interface
  - Demonstrates UploadSet custom control with file upload capability
  - Captures file metadata (filename, media type, file size) on upload
  - Stores uploaded files in an internal table with their associated metadata
  - Implements proper event handling for the `FILE_ADDED` event
  - Resets file data after each upload to prepare for the next file

## Implementation Details

- Uses the custom `uploadset_ext` control for enhanced file upload functionality
- Binds file data, filename, media type, and file size to UI controls via `_bind_edit()`
- Implements multi-select upload mode with instant upload enabled
- Maintains a table of uploaded files (`t_files`) with structure containing filename, media type, size, and file data
- Follows the standard abap2UI5 app lifecycle pattern with `check_on_init()` and `check_on_event()` checks

https://claude.ai/code/session_01BsmXw6xmR2t56FEn68zhyz