### PR TITLE
Refactor timestamp handling to use utility method

### DIFF
--- a/src/00/z2ui5_cl_demo_app_s_09.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_09.clas.abap
@@ -80,10 +80,11 @@ CLASS z2ui5_cl_demo_app_s_09 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just for demo
+    "GET TIME STAMP FIELD DATA(now).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
-    "      UPD_TMSTMP = @sy-uzeit
+    "      UPD_TMSTMP = @now
     "  WHERE vbeln = @vbeln.
     "COMMIT WORK.
 

--- a/src/00/z2ui5_cl_demo_app_s_09.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_09.clas.abap
@@ -80,7 +80,7 @@ CLASS z2ui5_cl_demo_app_s_09 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just for demo
-    "GET TIME STAMP FIELD DATA(now).
+    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,

--- a/src/00/z2ui5_cl_demo_app_s_10.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_10.clas.abap
@@ -102,11 +102,12 @@ CLASS z2ui5_cl_demo_app_s_10 IMPLEMENTATION.
 
     ENDIF.
 
-    "son't do that, just for demo
+    "don't do that, just for demo
+    "GET TIME STAMP FIELD DATA(now).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
-    "      UPD_TMSTMP = @sy-uzeit
+    "      UPD_TMSTMP = @now
     "  WHERE vbeln = @vbeln.
     "COMMIT WORK.
 

--- a/src/00/z2ui5_cl_demo_app_s_10.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_10.clas.abap
@@ -103,7 +103,7 @@ CLASS z2ui5_cl_demo_app_s_10 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just for demo
-    "GET TIME STAMP FIELD DATA(now).
+    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,

--- a/src/00/z2ui5_cl_demo_app_s_11.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_11.clas.abap
@@ -110,7 +110,7 @@ CLASS z2ui5_cl_demo_app_s_11 IMPLEMENTATION.
   METHOD on_event_save.
 
     "don't do that, just demo
-    "GET TIME STAMP FIELD DATA(now).
+    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,

--- a/src/00/z2ui5_cl_demo_app_s_11.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_11.clas.abap
@@ -110,10 +110,11 @@ CLASS z2ui5_cl_demo_app_s_11 IMPLEMENTATION.
   METHOD on_event_save.
 
     "don't do that, just demo
+    "GET TIME STAMP FIELD DATA(now).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,
-    "      UPD_TMSTMP = @sy-uzeit
+    "      UPD_TMSTMP = @now
     "  WHERE vbeln = @vbeln.
     "COMMIT WORK.
 

--- a/src/00/z2ui5_cl_demo_app_s_12.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_12.clas.abap
@@ -161,13 +161,14 @@ CLASS z2ui5_cl_demo_app_s_12 IMPLEMENTATION.
 
     ENDIF.
 
-   "don't do that, just demo
-   " UPDATE vbak
-   "   SET auart = @auart,
-   "       aedat = @sy-datum,
-   "       UPD_TMSTMP = @sy-uzeit
-   "   WHERE vbeln = @vbeln.
-   " COMMIT WORK.
+    "don't do that, just demo
+    "GET TIME STAMP FIELD DATA(now).
+    "UPDATE vbak
+    "  SET auart = @auart,
+    "      aedat = @sy-datum,
+    "      UPD_TMSTMP = @now
+    "  WHERE vbeln = @vbeln.
+    "COMMIT WORK.
 
     CALL FUNCTION 'DEQUEUE_EVVBAK'
       EXPORTING

--- a/src/00/z2ui5_cl_demo_app_s_12.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_12.clas.abap
@@ -92,7 +92,7 @@ CLASS z2ui5_cl_demo_app_s_12 IMPLEMENTATION.
     DATA s_new TYPE z2ui5_sample_01.
     s_new-vbeln    = vbeln.
     s_new-username = sy-uname.
-    GET TIME STAMP FIELD s_new-locked_at.
+    s_new-locked_at = z2ui5_cl_util=>time_get_timestampl( ).
 
     MODIFY z2ui5_sample_01 FROM @s_new.
     COMMIT WORK.
@@ -162,7 +162,7 @@ CLASS z2ui5_cl_demo_app_s_12 IMPLEMENTATION.
     ENDIF.
 
     "don't do that, just demo
-    "GET TIME STAMP FIELD DATA(now).
+    "DATA(now) = z2ui5_cl_util=>time_get_timestampl( ).
     "UPDATE vbak
     "  SET auart = @auart,
     "      aedat = @sy-datum,


### PR DESCRIPTION
## Summary
Standardize timestamp retrieval across demo apps by replacing direct `GET TIME STAMP` statements with a centralized utility method `z2ui5_cl_util=>time_get_timestampl()`. This improves code consistency and maintainability.

## Key Changes
- **z2ui5_cl_demo_app_s_12.clas.abap**: Replace `GET TIME STAMP FIELD s_new-locked_at` with utility method call; update commented demo code to show proper timestamp usage pattern
- **z2ui5_cl_demo_app_s_09.clas.abap**: Update commented demo code to use utility method for timestamp assignment
- **z2ui5_cl_demo_app_s_10.clas.abap**: Fix typo in comment ("son't" → "don't") and update demo code to use utility method
- **z2ui5_cl_demo_app_s_11.clas.abap**: Update commented demo code to use utility method for timestamp assignment

## Implementation Details
- All active timestamp assignments now use `z2ui5_cl_util=>time_get_timestampl()` instead of `GET TIME STAMP FIELD`
- Commented demo code blocks updated to show the recommended pattern: assign timestamp to a local variable before using it in UPDATE statements
- Improves code clarity by demonstrating best practices in demo applications

https://claude.ai/code/session_01UVtUPwmYpvvwgbjPxEQghn