### PR TITLE
Clean up code style and remove unnecessary ICF check

### DIFF
--- a/src/99/z2ui5_cl_demo_app_202_0.clas.abap
+++ b/src/99/z2ui5_cl_demo_app_202_0.clas.abap
@@ -50,7 +50,7 @@ CLASS z2ui5_cl_demo_app_202_0 IMPLEMENTATION.
     lr_wiz_step2->button(
 *      EXPORTING
         text  = `Press Step 2.2`
-        press = client->_event(`STEP22` ) ).
+        press = client->_event( `STEP22` ) ).
     lr_wiz_step2->button(
 *      EXPORTING
         text  = `Press Step 2.3`

--- a/src/99/z2ui5_cl_demo_app_s_03_0.clas.abap
+++ b/src/99/z2ui5_cl_demo_app_s_03_0.clas.abap
@@ -38,12 +38,6 @@ CLASS z2ui5_cl_demo_app_s_03_0 IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
 
-    SELECT
-      SINGLE FROM icfservloc
-      FIELDS icfactive
-      WHERE icf_name = `MIME_DEMO`
-      INTO @DATA(icfactive).
-
     " Note, these are demo sounds and are part of the abap2UI5 sample repo.
     " They are NOT meant to use in production.
     view->_generic( name = `script`
@@ -51,20 +45,13 @@ CLASS z2ui5_cl_demo_app_s_03_0 IMPLEMENTATION.
                         |function playSuccess() \{ new Audio("/SAP/PUBLIC/BC/ABAP/mime_demo/z2ui5_demo_success.mp3").play(); \}|
                      && |function playError() \{ new Audio("/SAP/PUBLIC/BC/ABAP/mime_demo/z2ui5_demo_error.mp3").play(); \}| ).
 
-    DATA(vbox) = view->page( `Play success and error sounds` )->vbox( class = `sapUiSmallMargin` ).
-
-    IF icfactive = abap_false.
-      vbox->message_strip(
-          text    = `ICF Service '/SAP/PUBLIC/BC/ABAP/mime_demo' is not active. Sounds will not play. Please activate the ICF service first.`
-          type    = `Warning`
-          visible = abap_true ).
-    ENDIF.
+    DATA(vbox) = view->page( `Play success and error sounds` )->vbox( `sapUiSmallMargin` ).
 
     vbox->message_strip(
         text    = client->_bind( message-text )
         type    = client->_bind( message-type )
         visible = `{= !!$` && client->_bind( message-text ) && ` }` ).
-    vbox->text( text = `The magic key is: abap2UI5` ).
+    vbox->text( `The magic key is: abap2UI5` ).
     vbox->input( id          = `inputApp`
                  value       = client->_bind_edit( magic_key )
                  placeholder = `Enter magic key`
@@ -73,7 +60,7 @@ CLASS z2ui5_cl_demo_app_s_03_0 IMPLEMENTATION.
                   type  = `accept`
                   press = client->_event( `enter` ) ).
 
-    view->_z2ui5( )->focus( focusid = `inputApp` ).
+    view->_z2ui5( )->focus( `inputApp` ).
     client->view_display( view->stringify( ) ).
 
   ENDMETHOD.

--- a/src/z2ui5_cl_demo_app_058.clas.abap
+++ b/src/z2ui5_cl_demo_app_058.clas.abap
@@ -200,7 +200,7 @@ CLASS z2ui5_cl_demo_app_058 IMPLEMENTATION.
       lo_columns->column(
             minscreenwidth = shift_right( CONV string( lv_width ) ) && `px`
             demandpopin    = abap_true
-            width          = lr_field->length )->text( CONV string( lr_field->title ) ).
+            width          = lr_field->length )->text( lr_field->title ).
       lv_width = lv_width + 10.
     ENDLOOP.
 

--- a/src/z2ui5_cl_demo_app_069.clas.abap
+++ b/src/z2ui5_cl_demo_app_069.clas.abap
@@ -97,7 +97,7 @@ CLASS z2ui5_cl_demo_app_069 IMPLEMENTATION.
           shownavbutton  = client->check_app_prev_stack( ) ).
 
     DATA(lr_master) = page->flexible_column_layout( layout = `TwoColumnsBeginExpanded`
-                                                    id     =`test` )->begin_column_pages( ).
+                                                    id     = `test` )->begin_column_pages( ).
 
     lr_master->tree( client->_bind( mt_tree ) )->items(
         )->standard_tree_item(

--- a/src/z2ui5_cl_demo_app_098.clas.abap
+++ b/src/z2ui5_cl_demo_app_098.clas.abap
@@ -105,7 +105,7 @@ CLASS z2ui5_cl_demo_app_098 IMPLEMENTATION.
             shownavbutton = abap_true ).
 
     DATA(col_layout) = page->flexible_column_layout( layout = client->_bind_edit( mv_layout )
-                                                     id     =`test` ).
+                                                     id     = `test` ).
 
     DATA(lr_master) = col_layout->begin_column_pages( ).
 

--- a/src/z2ui5_cl_demo_app_104.clas.abap
+++ b/src/z2ui5_cl_demo_app_104.clas.abap
@@ -85,7 +85,7 @@ CLASS z2ui5_cl_demo_app_104 IMPLEMENTATION.
             shownavbutton = abap_true ).
 
     DATA(col_layout) = page->flexible_column_layout( layout = client->_bind_edit( mv_layout )
-                                                     id     =`test` ).
+                                                     id     = `test` ).
 
     DATA(lr_master) = col_layout->begin_column_pages( ).
 

--- a/src/z2ui5_cl_demo_app_130.clas.abap
+++ b/src/z2ui5_cl_demo_app_130.clas.abap
@@ -367,14 +367,14 @@ CLASS z2ui5_cl_demo_app_130 IMPLEMENTATION.
       LOOP AT mt_fields REFERENCE INTO DATA(lr_tab).
         DATA(lv_tabix) = sy-tabix.
 
-        DATA(scrtext) = get_txt( CONV #( lr_tab->field_doma ) ).
+        DATA(scrtext) = get_txt( lr_tab->field_doma ).
 
         content->label( scrtext
           )->multi_input(
                    tokens           = client->_bind( val = lr_tab->t_token tab = mt_fields tab_index = lv_tabix )
                    showclearicon    = abap_true
                    id               = lr_tab->field
-                   valuehelprequest = client->_event( val = `CALL_POPUP_FILTER` t_arg = VALUE #( ( CONV #( lr_tab->field ) ) ) )
+                   valuehelprequest = client->_event( val = `CALL_POPUP_FILTER` t_arg = VALUE #( ( lr_tab->field ) ) )
                )->item(
                        key  = `{KEY}`
                        text = `{TEXT}`

--- a/src/z2ui5_cl_demo_app_202.clas.abap
+++ b/src/z2ui5_cl_demo_app_202.clas.abap
@@ -41,7 +41,7 @@ CLASS z2ui5_cl_demo_app_202 IMPLEMENTATION.
     lr_wiz_step2->button(
 *      EXPORTING
         text  = `Press Step 2.2`
-        press = client->_event(`STEP22` ) ).
+        press = client->_event( `STEP22` ) ).
     lr_wiz_step2->button(
 *      EXPORTING
         text  = `Press Step 2.3`


### PR DESCRIPTION
## Summary
This PR applies code style improvements and removes an obsolete ICF service availability check across multiple demo apps.

## Key Changes

- **Removed ICF service check** in `z2ui5_cl_demo_app_s_03_0`: Eliminated the `SELECT` query checking if the `/SAP/PUBLIC/BC/ABAP/mime_demo` ICF service is active and the associated warning message, as this check is no longer necessary.

- **Simplified method calls** by removing unnecessary `CONV` type conversions:
  - `z2ui5_cl_demo_app_130`: Removed `CONV #()` when passing `lr_tab->field_doma` to `get_txt()` and `lr_tab->field` to `_event()`
  - `z2ui5_cl_demo_app_058`: Removed `CONV string()` when passing `lr_field->title` to `text()`

- **Improved code formatting** for consistency:
  - Standardized spacing around assignment operators in method parameters (e.g., `id = `test`` instead of `id =`test``)
  - Adjusted spacing in method calls (e.g., `client->_event( `STEP22` )` instead of `client->_event(`STEP22` )`)
  - Simplified method parameter syntax (e.g., `vbox( `sapUiSmallMargin` )` instead of `vbox( class = `sapUiSmallMargin` )`)

- **Updated method calls** to use positional arguments where appropriate:
  - `view->_z2ui5( )->focus( `inputApp` )` instead of `focus( focusid = `inputApp` )`
  - `vbox->text( `The magic key is: abap2UI5` )` instead of `text( text = ... )`

## Files Modified
- `src/99/z2ui5_cl_demo_app_s_03_0.clas.abap`
- `src/z2ui5_cl_demo_app_130.clas.abap`
- `src/99/z2ui5_cl_demo_app_202_0.clas.abap`
- `src/z2ui5_cl_demo_app_058.clas.abap`
- `src/z2ui5_cl_demo_app_069.clas.abap`
- `src/z2ui5_cl_demo_app_098.clas.abap`
- `src/z2ui5_cl_demo_app_104.clas.abap`
- `src/z2ui5_cl_demo_app_202.clas.abap`

All changes align with the SAP ABAP Style Guide and project conventions.

https://claude.ai/code/session_01Cm8k1AzFsT9476zatCr5U4