### PR TITLE
Fix UI5 version structure reference in demo apps

### DIFF
--- a/src/z2ui5_cl_demo_app_122.clas.abap
+++ b/src/z2ui5_cl_demo_app_122.clas.abap
@@ -54,10 +54,10 @@ CLASS z2ui5_cl_demo_app_122 IMPLEMENTATION.
     device_touch           = ls_get-s_device-support-touch.
     device_pointer         = ls_get-s_device-support-pointer.
     device_retina          = ls_get-s_device-support-retina.
-    ui5_version            = ls_get-s_ui5_version-version.
-    ui5_theme              = ls_get-s_ui5_version-theme.
-    ui5_gav                = ls_get-s_ui5_version-gav.
-    ui5_build_timestamp    = ls_get-s_ui5_version-build_timestamp.
+    ui5_version            = ls_get-s_ui5-version.
+    ui5_theme              = ls_get-s_ui5-theme.
+    ui5_gav                = ls_get-s_ui5-gav.
+    ui5_build_timestamp    = ls_get-s_ui5-build_timestamp.
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_353.clas.abap
+++ b/src/z2ui5_cl_demo_app_353.clas.abap
@@ -34,8 +34,8 @@ CLASS z2ui5_cl_demo_app_353 IMPLEMENTATION.
     device_systemtype = ls_get-s_device-system.
     device_height     = CONV string( ls_get-s_device-resize-height ).
     device_width      = CONV string( ls_get-s_device-resize-width ).
-    ui5_version       = ls_get-s_ui5_version-version.
-    ui5_theme         = ls_get-s_ui5_version-theme.
+    ui5_version       = ls_get-s_ui5-version.
+    ui5_theme         = ls_get-s_ui5-theme.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Corrected the structure reference for UI5 version information in two demo apps. The code was accessing `s_ui5_version` when the correct structure name is `s_ui5`.

## Changes
- **z2ui5_cl_demo_app_122**: Updated four field references from `ls_get-s_ui5_version-*` to `ls_get-s_ui5-*`
  - `version`
  - `theme`
  - `gav`
  - `build_timestamp`

- **z2ui5_cl_demo_app_353**: Updated two field references from `ls_get-s_ui5_version-*` to `ls_get-s_ui5-*`
  - `version`
  - `theme`

## Details
This fix aligns the code with the correct data structure naming convention used by the framework's `get()` method, ensuring proper access to UI5 version metadata.

https://claude.ai/code/session_01N8YLbiB1wPEGiqsCRTARQ7