### PR TITLE
Add demo app 364: TreeTable with checkbox binding

### DIFF
--- a/src/z2ui5_cl_demo_app_000.clas.abap
+++ b/src/z2ui5_cl_demo_app_000.clas.abap
@@ -916,6 +916,12 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
                          mode      = `LineMode`
                          class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
 
+    panel->generic_tile( header    = `Tree Table II`
+                         subheader = `Checkbox Binding per Node`
+                         press     = client->_event( `Z2UI5_CL_DEMO_APP_364` )
+                         mode      = `LineMode`
+                         class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
+
     page = page2->panel( expandable = abap_true
                          expanded   = client->_bind_edit( ms_check_expanded-popups )
                          headertext = `Popups & Popovers` ).

--- a/src/z2ui5_cl_demo_app_364.clas.abap
+++ b/src/z2ui5_cl_demo_app_364.clas.abap
@@ -1,0 +1,124 @@
+CLASS z2ui5_cl_demo_app_364 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+*   https://github.com/abap2UI5/abap2UI5/issues/2290
+*   TreeTable with bound checkboxes - editing a checkbox and sending an
+*   event back to the server must not crash the JSON parsing.
+
+    INTERFACES z2ui5_if_app.
+
+    TYPES:
+      BEGIN OF ty_s_node,
+        user      TYPE string,
+        enabled   TYPE abap_bool,
+        validated TYPE abap_bool,
+      END OF ty_s_node.
+    TYPES:
+      BEGIN OF ty_s_tree,
+        user      TYPE string,
+        enabled   TYPE abap_bool,
+        validated TYPE abap_bool,
+        nodes     TYPE STANDARD TABLE OF ty_s_node WITH DEFAULT KEY,
+      END OF ty_s_tree.
+    TYPES ty_t_tree TYPE STANDARD TABLE OF ty_s_tree WITH DEFAULT KEY.
+
+    DATA t_tree TYPE ty_t_tree.
+
+  PROTECTED SECTION.
+    DATA client TYPE REF TO z2ui5_if_client.
+
+    METHODS on_init.
+    METHODS on_event.
+    METHODS view_display.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_demo_app_364 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+    IF client->check_on_init( ).
+      on_init( ).
+    ELSEIF client->check_on_event( ).
+      on_event( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD on_init.
+
+    t_tree = VALUE #(
+      ( user    = `Manager`
+        enabled = abap_false
+        nodes   = VALUE #(
+          ( user = `Employee 1` enabled = abap_true )
+          ( user = `Employee 2` enabled = abap_true )
+          ( user = `Employee 3` enabled = abap_true ) ) ) ).
+
+    view_display( ).
+
+  ENDMETHOD.
+
+
+  METHOD on_event.
+
+    CASE client->get( )-event.
+      WHEN `BUTTON_SAVE`.
+
+        DATA(counter) = 0.
+        LOOP AT t_tree INTO DATA(s_tree).
+          LOOP AT s_tree-nodes INTO DATA(s_node) WHERE validated = abap_true.
+            counter = counter + 1.
+          ENDLOOP.
+        ENDLOOP.
+
+        client->message_toast_display( |Saved { counter } checkbox(es)| ).
+
+    ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD view_display.
+
+    DATA(view) = z2ui5_cl_xml_view=>factory( ).
+    DATA(page) = view->shell(
+        )->page(
+            title          = `Account Validation`
+            navbuttonpress = client->_event_nav_app_leave( )
+            shownavbutton  = client->check_app_prev_stack( ) ).
+
+    page->overflow_toolbar(
+        )->content(
+            )->button(
+                icon  = `sap-icon://save`
+                text  = `Save`
+                press = client->_event( `BUTTON_SAVE` ) ).
+
+    DATA(columns) = page->tree_table(
+            id            = `treeTable`
+            rows          = `{path:'` && client->_bind_edit( val = t_tree path = abap_true )
+                         && `', parameters: {arrayNames:['NODES'], numberOfExpandedLevels: 1}}`
+            selectionmode = `None`
+        )->tree_columns( ).
+
+    columns->tree_column( `User`
+        )->tree_template(
+            )->text( `{USER}` ).
+
+    columns->tree_column( `Validated`
+        )->tree_template(
+            )->checkbox(
+                selected   = `{VALIDATED}`
+                enabled    = `{ENABLED}`
+                valuestate = `Success` ).
+
+    client->view_display( view->stringify( ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z2ui5_cl_demo_app_364.clas.xml
+++ b/src/z2ui5_cl_demo_app_364.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_364</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>tree table - checkbox binding</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary

Add a new demo app (`z2ui5_cl_demo_app_364`) that demonstrates TreeTable with bound checkboxes per node. This app addresses issue #2290 by showcasing proper handling of checkbox binding in hierarchical data structures and event processing without JSON parsing crashes.

## Changes

- **New demo app `z2ui5_cl_demo_app_364`**: Implements a TreeTable with a two-level hierarchy (Manager → Employees) where each node has an `enabled` and `validated` checkbox binding. The app demonstrates:
  - Proper data structure definition with nested nodes (`ty_s_tree` and `ty_s_node`)
  - TreeTable configuration with `arrayNames` parameter for correct hierarchical binding
  - Checkbox binding using `{VALIDATED}` and `{ENABLED}` expressions
  - Event handling to count validated checkboxes and display a toast message
  
- **Updated demo app index** (`z2ui5_cl_demo_app_000`): Added a new generic tile linking to the TreeTable II demo with the label "Checkbox Binding per Node"

## Implementation Details

- Uses `client->_bind_edit()` with `arrayNames: ['NODES']` to properly bind the nested table structure
- Demonstrates two-way binding for checkbox state changes in a hierarchical context
- Includes a SAVE button that iterates through the tree and counts validated entries
- Follows the abap2UI5 framework conventions for app structure and lifecycle management

https://claude.ai/code/session_016oad8KdySMJboAwknbTmte