### PR TITLE
Update event constant to set_title_launchpad in demo app LP 02

### DIFF
--- a/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
+++ b/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
@@ -43,13 +43,13 @@ CLASS z2ui5_cl_demo_app_lp_02 IMPLEMENTATION.
       client->view_display( view->stringify( ) ).
 
       client->action(
-          val   = z2ui5_if_client=>cs_event-set_title
+          val   = z2ui5_if_client=>cs_event-set_title_launchpad
           t_arg = VALUE #( ( mv_title ) ) ).
 
     ELSEIF client->check_on_event( `SET_TITLE` ).
 
       client->action(
-          val   = z2ui5_if_client=>cs_event-set_title
+          val   = z2ui5_if_client=>cs_event-set_title_launchpad
           t_arg = VALUE #( ( mv_title ) ) ).
 
     ENDIF.


### PR DESCRIPTION
## Summary
Updated the event constant used in the launchpad demo app to use the correct `set_title_launchpad` event instead of the generic `set_title` event.

## Changes
- Changed `z2ui5_if_client=>cs_event-set_title` to `z2ui5_if_client=>cs_event-set_title_launchpad` in two locations within the `main()` method
  - Initial view display action (line 46)
  - SET_TITLE event handler (line 52)

## Details
This change ensures the demo app uses the launchpad-specific title-setting event, which is the appropriate constant for this use case. The change maintains the same functionality while using the correct API constant.

https://claude.ai/code/session_01B32aq8HwaTFjzeQMomHsHg