### PR TITLE
Add demo app 365: CL_DEMO_OUTPUT popup integration

### DIFF
--- a/src/z2ui5_cl_demo_app_000.clas.abap
+++ b/src/z2ui5_cl_demo_app_000.clas.abap
@@ -1056,6 +1056,12 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
                          mode      = `LineMode`
                          class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
 
+    panel->generic_tile( header    = `Popup Display CL_DEMO_OUTPUT`
+                         subheader = ``
+                         press     = client->_event( `z2ui5_cl_demo_app_365` )
+                         mode      = `LineMode`
+                         class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
+
     page = page2->panel( expandable = abap_true
                          expanded   = client->_bind_edit( ms_check_expanded-features )
                          headertext = `More Controls` ).

--- a/src/z2ui5_cl_demo_app_365.clas.abap
+++ b/src/z2ui5_cl_demo_app_365.clas.abap
@@ -1,0 +1,67 @@
+CLASS z2ui5_cl_demo_app_365 DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    INTERFACES z2ui5_if_app.
+
+    DATA client TYPE REF TO z2ui5_if_client.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+CLASS z2ui5_cl_demo_app_365 IMPLEMENTATION.
+
+  METHOD z2ui5_if_app~main.
+
+    me->client = client.
+
+    IF client->check_on_init( ).
+
+      DATA(view) = z2ui5_cl_xml_view=>factory( ).
+      view->shell(
+          )->page(
+              title          = `abap2UI5 - Popup CL_DEMO_OUTPUT`
+              navbuttonpress = client->_event_nav_app_leave( )
+              shownavbutton  = client->check_app_prev_stack( )
+              )->button(
+                  text  = `Open CL_DEMO_OUTPUT Popup...`
+                  press = client->_event( `POPUP` ) ).
+      client->view_display( view->stringify( ) ).
+
+    ELSEIF client->check_on_event( `POPUP` ).
+
+      TYPES: BEGIN OF ty_s_carrier,
+               carrid TYPE c LENGTH 3,
+               name   TYPE string,
+               url    TYPE string,
+             END OF ty_s_carrier.
+      DATA t_carriers TYPE STANDARD TABLE OF ty_s_carrier WITH EMPTY KEY.
+      t_carriers = VALUE #(
+          ( carrid = `AA` name = `American Airlines`  url = `http://www.aa.com` )
+          ( carrid = `LH` name = `Lufthansa`          url = `http://www.lufthansa.com` )
+          ( carrid = `SQ` name = `Singapore Airlines` url = `http://www.singaporeair.com` ) ).
+
+      " CL_DEMO_OUTPUT is a classic ABAP class (not released for ABAP Cloud),
+      " so it is instantiated dynamically here to keep the sample portable.
+      " The popup itself accepts the output generically (TYPE REF TO object).
+      DATA output TYPE REF TO object.
+      CALL METHOD ('CL_DEMO_OUTPUT')=>('NEW')
+        RECEIVING
+          result = output.
+      CALL METHOD output->('WRITE_TEXT')
+        EXPORTING
+          text = `The HTML below is produced by the standard SAP class CL_DEMO_OUTPUT` &&
+                 ` and rendered inside an abap2UI5 popup. Use the footer button to`  &&
+                 ` toggle between popup and fullscreen.`.
+      CALL METHOD output->('WRITE_DATA')
+        EXPORTING
+          value = t_carriers.
+
+      client->nav_app_call( z2ui5_cl_pop_demo_output=>factory( output ) ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z2ui5_cl_demo_app_365.clas.xml
+++ b/src/z2ui5_cl_demo_app_365.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z2UI5_CL_DEMO_APP_365</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>popup - cl_demo_output html</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary

Add a new demo app that showcases integration of SAP's standard `CL_DEMO_OUTPUT` class within an abap2UI5 popup. This demonstrates how to dynamically instantiate and render classic ABAP classes in the framework.

## Changes

- **New demo app `z2ui5_cl_demo_app_365`**: Implements a simple UI with a button that opens a popup displaying HTML output generated by `CL_DEMO_OUTPUT`
  - On init: displays a button to trigger the popup
  - On event: dynamically instantiates `CL_DEMO_OUTPUT`, populates it with sample airline carrier data, and passes the output to a popup for rendering
  - Uses dynamic method calls (`CALL METHOD`) to maintain portability across ABAP environments (classic and cloud)
  - Demonstrates the `nav_app_call()` API for popup navigation

## Implementation Details

- Sample data includes three airline carriers (American Airlines, Lufthansa, Singapore Airlines) with carrier codes and URLs
- `CL_DEMO_OUTPUT` is instantiated dynamically to avoid hard dependencies on non-released classes
- The popup accepts the output generically as `TYPE REF TO object`, allowing flexible integration with various output producers

https://claude.ai/code/session_01FJbbe6gt9bQ49f3L6VznYs