### PR TITLE
Refactor demo app 365 to support popup and fullscreen modes

### DIFF
--- a/src/z2ui5_cl_demo_app_365.clas.abap
+++ b/src/z2ui5_cl_demo_app_365.clas.abap
@@ -6,6 +6,10 @@ CLASS z2ui5_cl_demo_app_365 DEFINITION PUBLIC.
     DATA client TYPE REF TO z2ui5_if_client.
 
   PROTECTED SECTION.
+    METHODS nav_to_output
+      IMPORTING
+        as_page TYPE abap_bool.
+
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -21,46 +25,69 @@ CLASS z2ui5_cl_demo_app_365 IMPLEMENTATION.
       DATA(view) = z2ui5_cl_xml_view=>factory( ).
       view->shell(
           )->page(
-              title          = `abap2UI5 - Popup CL_DEMO_OUTPUT`
+              title          = `abap2UI5 - CL_DEMO_OUTPUT`
               navbuttonpress = client->_event_nav_app_leave( )
               shownavbutton  = client->check_app_prev_stack( )
               )->button(
-                  text  = `Open CL_DEMO_OUTPUT Popup...`
-                  press = client->_event( `POPUP` ) ).
+                  text  = `Open in Popup`
+                  press = client->_event( `POPUP` )
+              )->button(
+                  text  = `Open as Fullscreen App`
+                  press = client->_event( `FULLSCREEN` ) ).
       client->view_display( view->stringify( ) ).
 
     ELSEIF client->check_on_event( `POPUP` ).
+      nav_to_output( abap_false ).
 
-      TYPES: BEGIN OF ty_s_carrier,
-               carrid TYPE c LENGTH 3,
-               name   TYPE string,
-               url    TYPE string,
-             END OF ty_s_carrier.
-      DATA t_carriers TYPE STANDARD TABLE OF ty_s_carrier WITH EMPTY KEY.
-      t_carriers = VALUE #(
-          ( carrid = `AA` name = `American Airlines`  url = `http://www.aa.com` )
-          ( carrid = `LH` name = `Lufthansa`          url = `http://www.lufthansa.com` )
-          ( carrid = `SQ` name = `Singapore Airlines` url = `http://www.singaporeair.com` ) ).
-
-      " CL_DEMO_OUTPUT is a classic ABAP class (not released for ABAP Cloud),
-      " so it is instantiated dynamically here to keep the sample portable.
-      " The popup itself accepts the output generically (TYPE REF TO object).
-      DATA output TYPE REF TO object.
-      CALL METHOD ('CL_DEMO_OUTPUT')=>('NEW')
-        RECEIVING
-          OUTPUT = output.
-      CALL METHOD output->('WRITE_TEXT')
-        EXPORTING
-          text = `The HTML below is produced by the standard SAP class CL_DEMO_OUTPUT` &&
-                 ` and rendered inside an abap2UI5 popup. Use the footer button to`  &&
-                 ` toggle between popup and fullscreen.`.
-      CALL METHOD output->('WRITE_DATA')
-        EXPORTING
-          value = t_carriers.
-
-      client->nav_app_call( z2ui5_cl_pop_demo_output=>factory( output ) ).
+    ELSEIF client->check_on_event( `FULLSCREEN` ).
+      nav_to_output( abap_true ).
 
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD nav_to_output.
+
+    TYPES: BEGIN OF ty_s_carrier,
+             carrid TYPE c LENGTH 3,
+             name   TYPE string,
+             url    TYPE string,
+           END OF ty_s_carrier.
+    DATA t_carriers TYPE STANDARD TABLE OF ty_s_carrier WITH EMPTY KEY.
+    t_carriers = VALUE #(
+        ( carrid = `AA` name = `American Airlines`  url = `http://www.aa.com` )
+        ( carrid = `LH` name = `Lufthansa`          url = `http://www.lufthansa.com` )
+        ( carrid = `SQ` name = `Singapore Airlines` url = `http://www.singaporeair.com` ) ).
+
+    DATA(xml) = `<?xml version="1.0" encoding="UTF-8"?>` &&
+                `<flightplan>` &&
+                `<flight carrid="LH" connid="0400" cityfrom="FRANKFURT" cityto="NEW YORK"/>` &&
+                `<flight carrid="AA" connid="0017" cityfrom="NEW YORK" cityto="SAN FRANCISCO"/>` &&
+                `</flightplan>`.
+
+    " CL_DEMO_OUTPUT is a classic ABAP class (not released for ABAP Cloud),
+    " so it is instantiated dynamically here to keep the sample portable.
+    " The popup itself accepts the output generically (TYPE REF TO object).
+    DATA output TYPE REF TO object.
+    CALL METHOD ('CL_DEMO_OUTPUT')=>('NEW')
+      RECEIVING
+        output = output.
+    CALL METHOD output->('WRITE_TEXT')
+      EXPORTING
+        text = `The HTML below is produced by the standard SAP class CL_DEMO_OUTPUT` &&
+               ` and rendered inside abap2UI5 - either as a popup or as a fullscreen` &&
+               ` app with a back button. It contains text, table data and XML.`.
+    CALL METHOD output->('WRITE_DATA')
+      EXPORTING
+        value = t_carriers.
+    CALL METHOD output->('WRITE_XML')
+      EXPORTING
+        xml = xml.
+
+    client->nav_app_call( z2ui5_cl_pop_demo_output=>factory(
+        i_output  = output
+        i_as_page = as_page ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary

Refactored the demo app to showcase `CL_DEMO_OUTPUT` in both popup and fullscreen modes. Extracted the output generation logic into a reusable protected method that accepts a parameter to control the display mode.

## Key Changes

- Added `nav_to_output()` protected method that accepts an `as_page` boolean parameter to control whether the output is displayed as a popup or fullscreen app
- Updated the main view to include two buttons: "Open in Popup" and "Open as Fullscreen App"
- Moved the `CL_DEMO_OUTPUT` instantiation and data population logic into the new method to eliminate duplication
- Enhanced the demo output to include XML data in addition to text and table data
- Updated the page title from "abap2UI5 - Popup CL_DEMO_OUTPUT" to "abap2UI5 - CL_DEMO_OUTPUT" to reflect the dual-mode functionality
- Modified the factory call to `z2ui5_cl_pop_demo_output` to pass both `i_output` and `i_as_page` parameters

## Implementation Details

The refactoring maintains the dynamic instantiation of `CL_DEMO_OUTPUT` to ensure portability across ABAP Cloud environments. The new method signature allows the same output generation logic to be reused for both display modes, reducing code duplication and improving maintainability.

https://claude.ai/code/session_01XamGLkuoXV93ZgzsGXDCVB