### PR TITLE
Refactor client action calls to use gen() method

### DIFF
--- a/src/00/z2ui5_cl_demo_app_s_03.clas.abap
+++ b/src/00/z2ui5_cl_demo_app_s_03.clas.abap
@@ -79,14 +79,14 @@ CLASS z2ui5_cl_demo_app_s_03 IMPLEMENTATION.
     IF client->get( )-event = `enter`.
 
       IF magic_key = `abap2UI5`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-play_audio
             t_arg = VALUE #( ( `/SAP/PUBLIC/BC/ABAP/mime_demo/z2ui5_demo_success.mp3` ) ) ).
         message-type = `Success`.
         message-text = `Hooray!`.
 
       ELSE.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-play_audio
             t_arg = VALUE #( ( `/SAP/PUBLIC/BC/ABAP/mime_demo/z2ui5_demo_error.mp3` ) ) ).
         message-type = `Error`.

--- a/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
+++ b/src/01/z2ui5_cl_demo_app_lp_02.clas.abap
@@ -42,13 +42,13 @@ CLASS z2ui5_cl_demo_app_lp_02 IMPLEMENTATION.
 
       client->view_display( view->stringify( ) ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_title_launchpad
           t_arg = VALUE #( ( mv_title ) ) ).
 
     ELSEIF client->check_on_event( `SET_TITLE` ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_title_launchpad
           t_arg = VALUE #( ( mv_title ) ) ).
 

--- a/src/03/z2ui5_cl_demo_app_309.clas.abap
+++ b/src/03/z2ui5_cl_demo_app_309.clas.abap
@@ -20,7 +20,7 @@ CLASS z2ui5_cl_demo_app_309 IMPLEMENTATION.
   METHOD on_event.
 
     IF client->check_on_event( `CUSTOM_JS_FROM_EB` ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-z2ui5
           t_arg = VALUE #( ( `afterBE` ) ) ).
     ENDIF.

--- a/src/99/z2ui5_cl_demo_app_180.clas.abap
+++ b/src/99/z2ui5_cl_demo_app_180.clas.abap
@@ -22,7 +22,7 @@ CLASS z2ui5_cl_demo_app_180 IMPLEMENTATION.
     IF client->check_on_event( `CALL_EF` ).
       mv_url = `https://www.google.com`.
       client->view_model_update( ).
-      client->action(
+      client->action->gen(
           val   = client->cs_event-open_new_tab
           t_arg = VALUE #( ( mv_url ) ) ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_000.clas.abap
+++ b/src/z2ui5_cl_demo_app_000.clas.abap
@@ -193,13 +193,13 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
                          class  = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
 
     panel->generic_tile( header    = `Scroll to position`
-                         subheader = `client->action( SCROLL_TO )`
+                         subheader = `client->action->gen( SCROLL_TO )`
                          press     = client->_event( `Z2UI5_CL_DEMO_APP_362` )
                          mode      = `LineMode`
                          class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).
 
     panel->generic_tile( header    = `Scroll into view`
-                         subheader = `client->action( SCROLL_INTO_VIEW )`
+                         subheader = `client->action->gen( SCROLL_INTO_VIEW )`
                          press     = client->_event( `Z2UI5_CL_DEMO_APP_363` )
                          mode      = `LineMode`
                          class     = `sapUiTinyMarginEnd sapUiTinyMarginBottom` ).

--- a/src/z2ui5_cl_demo_app_028.clas.abap
+++ b/src/z2ui5_cl_demo_app_028.clas.abap
@@ -83,7 +83,7 @@ CLASS z2ui5_cl_demo_app_028 IMPLEMENTATION.
 
   METHOD start_timer.
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-start_timer
         t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
 

--- a/src/z2ui5_cl_demo_app_071.clas.abap
+++ b/src/z2ui5_cl_demo_app_071.clas.abap
@@ -25,7 +25,7 @@ CLASS z2ui5_cl_demo_app_071 IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `UPDATE`.
-        client->action(
+        client->action->gen(
             val   = `SET_SIZE_LIMIT`
             t_arg = VALUE #( ( CONV #( mv_set_size_limit ) ) ( client->cs_view-main ) ) ).
         client->message_toast_display( `SizeLimitUpdated` ).

--- a/src/z2ui5_cl_demo_app_121.clas.abap
+++ b/src/z2ui5_cl_demo_app_121.clas.abap
@@ -28,7 +28,7 @@ CLASS z2ui5_cl_demo_app_121 IMPLEMENTATION.
 
       client->view_display( view->stringify( ) ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-start_timer
           t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
 

--- a/src/z2ui5_cl_demo_app_125.clas.abap
+++ b/src/z2ui5_cl_demo_app_125.clas.abap
@@ -35,7 +35,7 @@ CLASS z2ui5_cl_demo_app_125 IMPLEMENTATION.
 
     ELSEIF client->check_on_event( `SET_TITLE` ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_title
           t_arg = VALUE #( ( title ) ) ).
 

--- a/src/z2ui5_cl_demo_app_129.clas.abap
+++ b/src/z2ui5_cl_demo_app_129.clas.abap
@@ -75,7 +75,7 @@ CLASS z2ui5_cl_demo_app_129 IMPLEMENTATION.
       WHEN `REFRESH`.
         lv_text = lv_text + 10.
 
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-start_timer
             t_arg = VALUE #( ( client->_event( `REFRESH` ) ) ( `3000` ) ) ).
 
@@ -144,7 +144,7 @@ CLASS z2ui5_cl_demo_app_129 IMPLEMENTATION.
 
     client->view_display( page->stringify( ) ).
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-start_timer
         t_arg = VALUE #( ( client->_event( `REFRESH` ) ) ( `3000` ) ) ).
 

--- a/src/z2ui5_cl_demo_app_133.clas.abap
+++ b/src/z2ui5_cl_demo_app_133.clas.abap
@@ -75,7 +75,7 @@ CLASS z2ui5_cl_demo_app_133 IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `BUTTON01` OR `BUTTON02`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-set_focus
             t_arg = VALUE #( ( client->get( )-event ) ( selstart ) ( selend ) ) ).
         client->message_toast_display( |focus changed| ).

--- a/src/z2ui5_cl_demo_app_186.clas.abap
+++ b/src/z2ui5_cl_demo_app_186.clas.abap
@@ -42,7 +42,7 @@ CLASS z2ui5_cl_demo_app_186 IMPLEMENTATION.
   METHOD on_event.
 
     IF client->check_on_event( `BUTTON_DOWNLOAD` ).
-      client->action(
+      client->action->gen(
           val   = client->cs_event-download_b64_file
           t_arg = VALUE #( ( file_content_64 ) ( file_name ) ) ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_189.clas.abap
+++ b/src/z2ui5_cl_demo_app_189.clas.abap
@@ -23,11 +23,11 @@ CLASS z2ui5_cl_demo_app_189 IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `one_enter`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-set_focus
             t_arg = VALUE #( ( `IdTwo` ) ) ).
       WHEN `two_enter`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-set_focus
             t_arg = VALUE #( ( `IdThree` ) ) ).
     ENDCASE.
@@ -67,7 +67,7 @@ CLASS z2ui5_cl_demo_app_189 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       render( ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_focus
           t_arg = VALUE #( ( `IdOne` ) ) ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_202.clas.abap
+++ b/src/z2ui5_cl_demo_app_202.clas.abap
@@ -79,12 +79,12 @@ CLASS z2ui5_cl_demo_app_202 IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `STEP22`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-wizard_set_next_step
             t_arg = VALUE #( ( `wiz` ) ( `STEP2` ) ( `STEP22` ) ) ).
 
       WHEN `STEP23`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-wizard_set_next_step
             t_arg = VALUE #( ( `wiz` ) ( `STEP2` ) ( `STEP23` ) ) ).
 

--- a/src/z2ui5_cl_demo_app_315.clas.abap
+++ b/src/z2ui5_cl_demo_app_315.clas.abap
@@ -62,12 +62,12 @@ CLASS z2ui5_cl_demo_app_315 IMPLEMENTATION.
       client->view_display( val                       = view->stringify( )
                             switch_default_model_path = `` ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_odata_model
           t_arg = VALUE #( ( `/sap/opu/odata/DMO/API_TRAVEL_U_V2/` )
                            ( `TRAVEL` ) ) ).
 
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_odata_model
           t_arg = VALUE #( ( `/sap/opu/odata/DMO/ui_flight_r_v2/` )
                            ( `FLIGHT` ) ) ).

--- a/src/z2ui5_cl_demo_app_320.clas.abap
+++ b/src/z2ui5_cl_demo_app_320.clas.abap
@@ -286,7 +286,7 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
         content_width = `250px`.
 
         client->popover_model_update( ).
-        client->action(
+        client->action->gen(
             val   = `POPOVER_NAV_CONTAINER_TO`
             t_arg = VALUE #( ( `navContainer` ) ( `detail` ) ) ).
       WHEN `onNavBack`.
@@ -294,7 +294,7 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
         content_width = `450px`.
 
         client->popover_model_update( ).
-        client->action(
+        client->action->gen(
             val   = `POPOVER_NAV_CONTAINER_TO`
             t_arg = VALUE #( ( `navContainer` ) ( `main` ) ) ).
     ENDCASE.

--- a/src/z2ui5_cl_demo_app_323.clas.abap
+++ b/src/z2ui5_cl_demo_app_323.clas.abap
@@ -35,7 +35,7 @@ CLASS z2ui5_cl_demo_app_323 IMPLEMENTATION.
     CASE client->get( )-event.
 
       WHEN `BUTTON_POST`.
-        client->action( z2ui5_if_client=>cs_event-clipboard_app_state ).
+        client->action->gen( z2ui5_if_client=>cs_event-clipboard_app_state ).
         client->message_toast_display( `clipboard copied` ).
 
       WHEN `BACK`.

--- a/src/z2ui5_cl_demo_app_325.clas.abap
+++ b/src/z2ui5_cl_demo_app_325.clas.abap
@@ -73,13 +73,13 @@ CLASS z2ui5_cl_demo_app_325 IMPLEMENTATION.
 
     CASE client->get( )-event.
       WHEN `COPY_INPUT`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-clipboard_copy
             t_arg = VALUE #( ( input ) ) ).
         client->message_toast_display( `input field copied` && input ).
 
       WHEN `COPY_TEXT_AREA`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-clipboard_copy
             t_arg = VALUE #( ( text ) ) ).
         client->message_toast_display( `text area copied: ` && text ).

--- a/src/z2ui5_cl_demo_app_352.clas.abap
+++ b/src/z2ui5_cl_demo_app_352.clas.abap
@@ -23,10 +23,10 @@ CLASS z2ui5_cl_demo_app_352 IMPLEMENTATION.
 
     IF client->check_on_init( ).
       view_display( ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_focus
           t_arg = VALUE #( ( `ZINPUT` ) ) ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-keyboard_set_mode
           t_arg = VALUE #( ( `ZINPUT` ) ( `numeric` ) ) ).
     ENDIF.
@@ -66,7 +66,7 @@ CLASS z2ui5_cl_demo_app_352 IMPLEMENTATION.
   METHOD on_event.
 
     IF client->check_on_event( `CALL_KEYBOARD` ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-keyboard_set_mode
           t_arg = VALUE #( ( `ZINPUT` ) ( `none` ) ) ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_353.clas.abap
+++ b/src/z2ui5_cl_demo_app_353.clas.abap
@@ -42,7 +42,7 @@ CLASS z2ui5_cl_demo_app_353 IMPLEMENTATION.
 
   METHOD start_timer.
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-start_timer
         t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `4000` ) ) ).
 
@@ -92,7 +92,7 @@ CLASS z2ui5_cl_demo_app_353 IMPLEMENTATION.
       read_device_info( ).
       render( ).
       start_timer( ).
-      client->action(
+      client->action->gen(
           val   = z2ui5_if_client=>cs_event-set_focus
           t_arg = VALUE #( ( `IdOne` ) ) ).
     ENDIF.

--- a/src/z2ui5_cl_demo_app_362.clas.abap
+++ b/src/z2ui5_cl_demo_app_362.clas.abap
@@ -59,20 +59,20 @@ CLASS z2ui5_cl_demo_app_362 IMPLEMENTATION.
     " behavior is one of: "auto" (default, instant), "smooth", "instant".
     CASE client->get( )-event.
       WHEN `SCROLL_TOP`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-scroll_to
             t_arg = VALUE #( ( `id_page` ) ( `0` ) ( `0` ) ( `smooth` ) ) ).
       WHEN `SCROLL_MIDDLE`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-scroll_to
             t_arg = VALUE #( ( `id_page` ) ( `1500` ) ( `0` ) ( `smooth` ) ) ).
       WHEN `SCROLL_BOTTOM`.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-scroll_to
             t_arg = VALUE #( ( `id_page` ) ( `99999` ) ( `0` ) ( `smooth` ) ) ).
       WHEN `SCROLL_JUMP`.
         " Same target as middle but without smooth - instant snap.
-        client->action(
+        client->action->gen(
             val   = z2ui5_if_client=>cs_event-scroll_to
             t_arg = VALUE #( ( `id_page` ) ( `1500` ) ( `0` ) ) ).
       WHEN `REFRESH`.
@@ -94,7 +94,7 @@ CLASS z2ui5_cl_demo_app_362 IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-scroll_to
         t_arg = VALUE #( ( scroll-id )
                          ( |{ scroll-y }| )

--- a/src/z2ui5_cl_demo_app_363.clas.abap
+++ b/src/z2ui5_cl_demo_app_363.clas.abap
@@ -57,7 +57,7 @@ CLASS z2ui5_cl_demo_app_363 IMPLEMENTATION.
         RETURN.
     ENDCASE.
 
-    client->action(
+    client->action->gen(
         val   = z2ui5_if_client=>cs_event-scroll_into_view
         t_arg = VALUE #( ( target ) ( behavior ) ( block ) ) ).
 


### PR DESCRIPTION
## Summary

Updated all demo app classes to use the new `client->action->gen()` method signature instead of the direct `client->action()` call. This refactoring standardizes the action invocation pattern across the codebase.

## Changes

- **Refactored action calls**: Changed all instances of `client->action(...)` to `client->action->gen(...)` across 16 demo app classes
- **Updated documentation strings**: Modified UI5 tile descriptions in the main demo app to reflect the new method signature
- **Affected classes**:
  - `z2ui5_cl_demo_app_362` (scroll actions)
  - `z2ui5_cl_demo_app_189` (focus actions)
  - `z2ui5_cl_demo_app_352` (keyboard mode actions)
  - `z2ui5_cl_demo_app_s_03` (audio playback)
  - `z2ui5_cl_demo_app_lp_02` (launchpad title)
  - `z2ui5_cl_demo_app_000` (documentation)
  - `z2ui5_cl_demo_app_129` (timer actions)
  - `z2ui5_cl_demo_app_202` (wizard navigation)
  - `z2ui5_cl_demo_app_315` (OData model setup)
  - `z2ui5_cl_demo_app_320` (popover navigation)
  - `z2ui5_cl_demo_app_325` (clipboard actions)
  - `z2ui5_cl_demo_app_353` (timer and focus)
  - `z2ui5_cl_demo_app_309` (custom JavaScript)
  - `z2ui5_cl_demo_app_180` (new tab opening)
  - `z2ui5_cl_demo_app_028` (timer)
  - `z2ui5_cl_demo_app_071` (size limit)
  - `z2ui5_cl_demo_app_121` (timer)
  - `z2ui5_cl_demo_app_125` (title setting)
  - `z2ui5_cl_demo_app_133` (focus with selection)
  - `z2ui5_cl_demo_app_186` (file download)
  - `z2ui5_cl_demo_app_323` (clipboard app state)
  - `z2ui5_cl_demo_app_363` (scroll into view)

## Implementation Details

All action invocations maintain the same parameter structure (`val` and `t_arg`). The change is purely a method call refactoring to align with the updated client API interface.

https://claude.ai/code/session_0123tcSwjTWxoGTG6YossyaN