### PR TITLE
Refactor UI actions to use client action API instead of view methods

### DIFF
--- a/src/z2ui5_cl_demo_app_000.clas.abap
+++ b/src/z2ui5_cl_demo_app_000.clas.abap
@@ -15,8 +15,12 @@ CLASS z2ui5_cl_demo_app_000 DEFINITION PUBLIC.
         version    TYPE abap_bool,
       END OF ms_check_expanded.
 
-    DATA mt_scroll     TYPE z2ui5_if_types=>ty_t_name_value.
-    DATA mv_set_scroll TYPE abap_bool.
+    DATA:
+      BEGIN OF s_scroll,
+        id TYPE string,
+        x  TYPE i,
+        y  TYPE i,
+      END OF s_scroll.
 
     METHODS expand_all.
 
@@ -31,12 +35,12 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
 
     CONSTANTS c_title TYPE string VALUE ` abap2UI5 - Samples`.
 
-    IF client->get( )-check_on_navigated = abap_true.
-
-      IF mt_scroll IS INITIAL.
-        mt_scroll = VALUE #( ( n = `page` ) ).
-      ENDIF.
-      mv_set_scroll = abap_true.
+    IF client->get( )-check_on_navigated = abap_true AND s_scroll-id IS NOT INITIAL.
+      client->action->gen(
+          val   = z2ui5_if_client=>cs_event-scroll_to
+          t_arg = VALUE #( ( s_scroll-id )
+                           ( |{ s_scroll-y }| )
+                           ( |{ s_scroll-x }| ) ) ).
     ENDIF.
 
     CASE client->get( )-event.
@@ -49,6 +53,7 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
             DATA(lv_classname) = to_upper( client->get( )-event ).
             DATA li_app TYPE REF TO z2ui5_if_app.
             CREATE OBJECT li_app TYPE (lv_classname).
+            s_scroll = CORRESPONDING #( client->get( )-s_scroll-main ).
             client->nav_app_call( li_app ).
             RETURN.
           CATCH cx_root.
@@ -68,11 +73,10 @@ CLASS z2ui5_cl_demo_app_000 IMPLEMENTATION.
         )->get_parent( ).
 
     IF client->get( )-check_launchpad_active = abap_true.
-      page->_z2ui5( )->lp_title( c_title ).
+      client->action->gen(
+          val   = z2ui5_if_client=>cs_event-set_title_launchpad
+          t_arg = VALUE #( ( c_title ) ) ).
     ENDIF.
-
-    page->_z2ui5( )->scrolling( setupdate = client->_bind_edit( mv_set_scroll )
-                                items     = client->_bind_edit( mt_scroll ) ).
 
 *    page = page->grid( `L12 M12 S12`
 *         )->content( `layout` ).

--- a/src/z2ui5_cl_demo_app_049.clas.abap
+++ b/src/z2ui5_cl_demo_app_049.clas.abap
@@ -60,6 +60,9 @@ CLASS z2ui5_cl_demo_app_049 IMPLEMENTATION.
 
       ENDDO.
 
+      client->action->gen(
+          val   = z2ui5_if_client=>cs_event-start_timer
+          t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
       client->view_model_update( ).
     ENDIF.
 
@@ -79,9 +82,6 @@ CLASS z2ui5_cl_demo_app_049 IMPLEMENTATION.
   METHOD view_display.
 
     DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
-    lo_view->_z2ui5( )->timer( finished    = client->_event( `TIMER_FINISHED` )
-                               delayms     = `2000`
-                               checkrepeat = abap_true ).
     DATA(page) = lo_view->shell( )->page(
              title          = `abap2UI5 - CL_GUI_TIMER - Monitor`
              navbuttonpress = client->_event_nav_app_leave( )
@@ -108,6 +108,10 @@ CLASS z2ui5_cl_demo_app_049 IMPLEMENTATION.
              info        = `{INFO}` ).
 
     client->view_display( lo_view->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-start_timer
+        t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_064.clas.abap
+++ b/src/z2ui5_cl_demo_app_064.clas.abap
@@ -96,6 +96,13 @@ CLASS z2ui5_cl_demo_app_064 IMPLEMENTATION.
 
       client->message_toast_display( `loaded` ).
       WAIT UP TO 2 SECONDS.
+
+      IF mv_check_active = abap_true.
+        client->action->gen(
+            val   = z2ui5_if_client=>cs_event-start_timer
+            t_arg = VALUE #( ( client->_event( `LOAD` ) ) ( `0` ) ) ).
+      ENDIF.
+
       client->view_model_update( ).
 
     ENDIF.
@@ -114,10 +121,6 @@ CLASS z2ui5_cl_demo_app_064 IMPLEMENTATION.
 
     mv_check_enabled = abap_true.
     view = z2ui5_cl_xml_view=>factory( ).
-
-    view->_z2ui5( )->timer(
-        finished    = client->_event( `LOAD` )
-        checkactive = client->_bind( mv_check_active ) ).
 
     temp5 = client->check_app_prev_stack( ).
     page1 = view->shell( )->page( id = `page_main`

--- a/src/z2ui5_cl_demo_app_073.clas.abap
+++ b/src/z2ui5_cl_demo_app_073.clas.abap
@@ -3,9 +3,6 @@ CLASS z2ui5_cl_demo_app_073 DEFINITION PUBLIC.
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
 
-    DATA mv_url TYPE string.
-    DATA mv_check_timer_active TYPE abap_bool.
-
     DATA client TYPE REF TO z2ui5_if_client.
 
     METHODS view_display.
@@ -25,10 +22,6 @@ CLASS z2ui5_cl_demo_app_073 IMPLEMENTATION.
                   title          = `abap2UI5 - First Example`
                   navbuttonpress = client->_event_nav_app_leave( )
                   shownavbutton  = client->check_app_prev_stack( )
-             )->_z2ui5( )->timer(
-                  checkactive = client->_bind( mv_check_timer_active )
-                  finished    = client->_event_client( val     = client->cs_event-open_new_tab
-                                                         t_arg = VALUE #( ( `$` && client->_bind( mv_url ) ) ) )
               )->simple_form( title    = `Form Title`
                               editable = abap_true
                   )->content( `form`
@@ -45,16 +38,15 @@ CLASS z2ui5_cl_demo_app_073 IMPLEMENTATION.
     me->client = client.
 
     IF client->check_on_init( ).
-      mv_check_timer_active = abap_false.
       view_display( ).
     ENDIF.
 
     CASE client->get( )-event.
 
       WHEN `BUTTON_OPEN_NEW_TAB`.
-        mv_check_timer_active = abap_true.
-        mv_url = `https://www.google.com/search?q=abap2ui5&oq=abap2ui5,123`.
-        client->view_model_update( ).
+        client->action->gen(
+            val   = z2ui5_if_client=>cs_event-open_new_tab
+            t_arg = VALUE #( ( `https://www.google.com/search?q=abap2ui5&oq=abap2ui5,123` ) ) ).
     ENDCASE.
 
   ENDMETHOD.

--- a/src/z2ui5_cl_demo_app_082.clas.abap
+++ b/src/z2ui5_cl_demo_app_082.clas.abap
@@ -51,6 +51,9 @@ CLASS z2ui5_cl_demo_app_082 IMPLEMENTATION.
       INSERT VALUE #( title = `entry` && mv_counter   info = `completed`   descr = `this is a description` icon = `sap-icon://account` )
           INTO TABLE t_tab.
 
+      client->action->gen(
+          val   = z2ui5_if_client=>cs_event-start_timer
+          t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
       client->view_model_update( ).
     ENDIF.
 
@@ -71,10 +74,6 @@ CLASS z2ui5_cl_demo_app_082 IMPLEMENTATION.
 
     DATA(lo_view) = z2ui5_cl_xml_view=>factory( ).
 
-    lo_view->_z2ui5( )->timer( finished    = client->_event( `TIMER_FINISHED` )
-                               delayms     = `2000`
-                               checkrepeat = abap_true ).
-
     DATA(page) = lo_view->shell( )->page(
              title          = `abap2UI5 - Roundtrip Speed Test`
              navbuttonpress = client->_event_nav_app_leave( )
@@ -90,6 +89,10 @@ CLASS z2ui5_cl_demo_app_082 IMPLEMENTATION.
              info        = `{INFO}` ).
 
     client->view_display( lo_view->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-start_timer
+        t_arg = VALUE #( ( client->_event( `TIMER_FINISHED` ) ) ( `2000` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_118.clas.abap
+++ b/src/z2ui5_cl_demo_app_118.clas.abap
@@ -43,7 +43,7 @@ CLASS z2ui5_cl_demo_app_118 IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
 
-    DATA(page) = view->_z2ui5( )->title( `ABAP2UI5 Weird behavior showcase` )->shell(
+    DATA(page) = view->shell(
         )->page(
             title          = `ABAP2UI5 Weird behavior showcase`
             navbuttonpress = client->_event( `BACK` )
@@ -99,6 +99,10 @@ CLASS z2ui5_cl_demo_app_118 IMPLEMENTATION.
                  )->text( `{ATIME}` ).
 
     client->view_display( view->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-set_title
+        t_arg = VALUE #( ( `ABAP2UI5 Weird behavior showcase` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_279.clas.abap
+++ b/src/z2ui5_cl_demo_app_279.clas.abap
@@ -53,11 +53,13 @@ CLASS z2ui5_cl_demo_app_279 IMPLEMENTATION.
       class   = `sapUiSmallMarginBegin`
       visible = client->_bind( dirty ) ).
 
-    page->_z2ui5( )->focus( `input` ).
-
     page->_z2ui5( )->dirty( client->_bind( dirty ) ).
 
     client->view_display( page->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-set_focus
+        t_arg = VALUE #( ( `input` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_307.clas.abap
+++ b/src/z2ui5_cl_demo_app_307.clas.abap
@@ -192,8 +192,6 @@ CLASS z2ui5_cl_demo_app_307 IMPLEMENTATION.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
 
-    view->_z2ui5( )->title( `Grid List with Drag and Drop` ).
-
     DATA(page) = view->shell(
         )->page( title          = `Grid List with Drag and Drop`
                  navbuttonpress = client->_event_nav_app_leave( )
@@ -241,6 +239,10 @@ CLASS z2ui5_cl_demo_app_307 IMPLEMENTATION.
                                   wrapping = abap_true ).
 
     client->view_display( view->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-set_title
+        t_arg = VALUE #( ( `Grid List with Drag and Drop` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_316.clas.abap
+++ b/src/z2ui5_cl_demo_app_316.clas.abap
@@ -40,7 +40,6 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
                      new_window = `true` ).
 
     DATA(page) = z2ui5_cl_xml_view=>factory(
-        )->_z2ui5( )->title( `URL Helper Sample`
         )->shell(
             )->page( title          = `abap2UI5 - Sample: URL Helper`
                      navbuttonpress = client->_event_nav_app_leave( )
@@ -133,6 +132,10 @@ CLASS z2ui5_cl_demo_app_316 IMPLEMENTATION.
                                                                       ( |${ client->_bind_edit( url ) }| ) ) ) ).
 
     client->view_display( page->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-set_title
+        t_arg = VALUE #( ( `URL Helper Sample` ) ) ).
 
   ENDMETHOD.
 

--- a/src/z2ui5_cl_demo_app_320.clas.abap
+++ b/src/z2ui5_cl_demo_app_320.clas.abap
@@ -89,7 +89,6 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
   METHOD display_avatar_group_view.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( ).
-    view->_z2ui5( )->title( `Avatar Group Sample` ).
     view->page( title          = `abap2UI5 - Sample: Avatar Group`
                 navbuttonpress = client->_event_nav_app_leave( )
                 shownavbutton  = client->check_app_prev_stack( )
@@ -138,6 +137,10 @@ CLASS z2ui5_cl_demo_app_320 IMPLEMENTATION.
                                           fallbackicon = `{FALLBACKICON}`
                                           src          = `{SRC}` ).
     client->view_display( view->stringify( ) ).
+
+    client->action->gen(
+        val   = z2ui5_if_client=>cs_event-set_title
+        t_arg = VALUE #( ( `Avatar Group Sample` ) ) ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary

This PR refactors multiple demo apps to use the new `client->action->gen()` API for triggering UI actions (timers, focus, title, scroll) instead of calling view builder methods like `_z2ui5()->timer()`, `_z2ui5()->focus()`, and `_z2ui5()->title()`. This aligns with the framework's shift toward a more explicit action-based architecture.

## Key Changes

- **z2ui5_cl_demo_app_000**: Replaced scroll state management (`mt_scroll`, `mv_set_scroll`) with a structured `s_scroll` variable. Removed view-based scrolling setup and replaced with `client->action->gen()` call using `cs_event-scroll_to`. Replaced `lp_title()` view method with `client->action->gen()` using `cs_event-set_title_launchpad`.

- **z2ui5_cl_demo_app_073**: Removed timer and URL state attributes (`mv_url`, `mv_check_timer_active`). Replaced view-based timer setup with direct `client->action->gen()` call using `cs_event-open_new_tab` when the button is clicked.

- **z2ui5_cl_demo_app_064**: Removed view-based timer setup. Added `client->action->gen()` call using `cs_event-start_timer` in the event handler when the timer completes.

- **z2ui5_cl_demo_app_082**: Removed view-based timer setup. Added `client->action->gen()` calls using `cs_event-start_timer` in both the event handler and view display method.

- **z2ui5_cl_demo_app_049**: Removed view-based timer setup. Added `client->action->gen()` calls using `cs_event-start_timer` in both the event handler and view display method.

- **z2ui5_cl_demo_app_118**: Removed `_z2ui5()->title()` view method call. Added `client->action->gen()` call using `cs_event-set_title` in the view display method.

- **z2ui5_cl_demo_app_279**: Removed `_z2ui5()->focus()` view method call. Added `client->action->gen()` call using `cs_event-set_focus` in the view display method.

- **z2ui5_cl_demo_app_307**: Removed `_z2ui5()->title()` view method call. Added `client->action->gen()` call using `cs_event-set_title` in the view display method.

- **z2ui5_cl_demo_app_316**: Removed `_z2ui5()->title()` view method call. Added `client->action->gen()` call using `cs_event-set_title` in the view display method.

- **z2ui5_cl_demo_app_320**: Removed `_z2ui5()->title()` view method call. Added `client->action->gen()` call using `cs_event-set_title` in the view display method.

## Implementation Details

- All timer actions now use `cs_event-start_timer` with event name and delay in milliseconds as arguments.
- Title actions use `cs_event-set_title` or `cs_event-set_title_launchpad` with the title string as an argument.
- Focus actions use `cs_event-set_focus` with the control ID as an argument.
- Scroll actions use `cs_event-scroll_to` with ID, Y position, and X position as arguments.
- State management for transient UI actions (timers, URLs) has been removed from class attributes where the action is now triggered directly via the client API.

https://claude.ai/code/session_013vV6hf86priocTxjQCFC4v