### PR TITLE
Update actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/ABAP_702.yaml
+++ b/.github/workflows/ABAP_702.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         ref: 702
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v5
       with:
         node-version: 20
     - run: npm ci

--- a/.github/workflows/ABAP_CLOUD.yaml
+++ b/.github/workflows/ABAP_CLOUD.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 20
     - run: npm ci

--- a/.github/workflows/ABAP_STANDARD.yaml
+++ b/.github/workflows/ABAP_STANDARD.yaml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 20
     - run: npm ci

--- a/.github/workflows/auto_cloud.yaml
+++ b/.github/workflows/auto_cloud.yaml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: '16'
 

--- a/.github/workflows/auto_downport.yaml
+++ b/.github/workflows/auto_downport.yaml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: '16'
 

--- a/.github/workflows/check_downport.yaml
+++ b/.github/workflows/check_downport.yaml
@@ -9,10 +9,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: '16'
 


### PR DESCRIPTION
Updates `actions/checkout` and `actions/setup-node` from v3 to v5 in all six workflows (`ABAP_702`, `ABAP_CLOUD`, `ABAP_STANDARD`, `auto_cloud`, `auto_downport`, `check_downport`).

The v3 versions run on Node.js 16, which has been shut down on GitHub Actions runners; v5 runs natively on Node.js 24 and resolves the deprecation warnings.

The `node-version` inputs of the `setup-node` steps are unchanged — they control the Node version for the workflow's own tooling and are unrelated to the deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvMa8UsRXirdKELSdiAD45

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvMa8UsRXirdKELSdiAD45)_