### PR TITLE
Add GitHub Actions workflow for launchpad generation

### DIFF
--- a/.github/workflows/launchpad.yaml
+++ b/.github/workflows/launchpad.yaml
@@ -1,0 +1,35 @@
+name: launchpad
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  launchpad:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v5
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: 20
+
+    - run: npm ci
+    - run: npm run launchpad
+
+    - name: Commit Changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add src
+        if git diff --cached --quiet; then
+          echo "Launchpad already up to date, nothing to commit."
+        else
+          git commit -m "Regenerate launchpad"
+          git push
+        fi


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automates the generation and deployment of launchpad artifacts.

## Key Changes
- Added `.github/workflows/launchpad.yaml` workflow file that:
  - Runs on manual trigger (`workflow_dispatch`)
  - Sets up Node.js 20 environment
  - Installs dependencies via `npm ci`
  - Executes `npm run launchpad` to generate launchpad artifacts
  - Automatically commits and pushes changes to the `src` directory if modifications are detected
  - Uses GitHub Actions bot credentials for commits
  - Includes a safety check to skip commits when launchpad is already up to date

## Implementation Details
- The workflow has a 10-minute timeout to prevent hanging jobs
- Only commits are made when there are actual changes (via `git diff --cached --quiet`)
- Requires `contents: write` permission to push changes back to the repository

https://claude.ai/code/session_01JJ4kryibeFNN9t8WBDAYY7