### PR TITLE
Restrict launchpad workflow to standard branch

### DIFF
--- a/.github/workflows/launchpad.yaml
+++ b/.github/workflows/launchpad.yaml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   launchpad:
+    if: github.ref == 'refs/heads/standard'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary
Restrict the launchpad GitHub Actions workflow to only run on the `standard` branch by adding a conditional check.

## Changes
- Added `if: github.ref == 'refs/heads/standard'` condition to the launchpad job to prevent it from executing on other branches

## Details
This ensures that launchpad generation only occurs on the designated standard branch, preventing unintended workflow executions on feature branches or other development branches.

https://claude.ai/code/session_01GRWA9rVwamfif1syS1zmqw