### PR TITLE
Rename launchpad classes to include "_app_" in class name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,8 @@ There is **one launchpad per top-level package**, and they cross-link:
 
 | App class                | Lives in | Title                            | Mirrors     | Button → other |
 |--------------------------|----------|----------------------------------|-------------|----------------|
-| `z2ui5_cl_sample_000`    | `src/01` | `abap2UI5 - Samples`             | `src/01/**` | "Extended Samples" → `sample_001` |
-| `z2ui5_cl_sample_001`    | `src/00` | `abap2UI5 - Samples (restricted)`| `src/00/**` | "Basic Samples" → `sample_000` |
+| `z2ui5_cl_sample_app_000`| `src/01` | `abap2UI5 - Samples`             | `src/01/**` | "Extended Samples" → `sample_app_001` |
+| `z2ui5_cl_sample_app_001`| `src/00` | `abap2UI5 - Samples (restricted)`| `src/00/**` | "Basic Samples" → `sample_app_000` |
 
 Both are identical in shape: a `get_catalog( )` method returning a flat table of
 tiles, and a `view_display( )` that loops the catalog, emitting an H3 section
@@ -120,7 +120,7 @@ so `Binding`, `Binding I` … `Binding VIII` render as one block, then a gap, th
 the `Event` block, and so on.
 
 `z2ui5_cl_demo_app_000` is the old "classic" launchpad (now under `00/99`,
-obsolete); `sample_000` links to it via a message strip. Do not extend it.
+obsolete); `sample_app_000` links to it via a message strip. Do not extend it.
 
 ---
 
@@ -173,8 +173,8 @@ from the old catalog.
 
 ### Generation rules
 
-1. **One catalog per area.** Apps in `src/01/**` belong in `sample_000`; apps in
-   `src/00/**` belong in `sample_001`. Never list an app in the wrong launchpad.
+1. **One catalog per area.** Apps in `src/01/**` belong in `sample_app_000`; apps in
+   `src/00/**` belong in `sample_app_001`. Never list an app in the wrong launchpad.
 2. **Each app appears exactly once**, and every demo app physically present in an
    area is listed (no missing tiles) — **except hidden helper apps**: a class
    whose `<DESCRIPT>` header is `ZZZ` (e.g. `ZZZ - called by SubApp I`) is only
@@ -196,7 +196,7 @@ from the old catalog.
 6. **Moving a subpackage = moving its whole tile group** between the two
    catalogs, inserted at the correct numeric slot (e.g. the uncategorized move
    `src/01/07` → `src/00/11` lifted the entire `uncategorized` group out of
-   `sample_000` and into `sample_001`).
+   `sample_app_000` and into `sample_app_001`).
 7. After every change, verify: `get_catalog( )` and the folder tree agree —
    same apps, same group names (== CTEXT), same grouping, no app in the wrong
    launchpad, none missing. The safest way to regenerate is to rebuild each

--- a/scripts/generate-launchpad.js
+++ b/scripts/generate-launchpad.js
@@ -12,7 +12,7 @@
  *      Apps whose header is "ZZZ" are helper apps (called only by other apps)
  *      and are skipped.
  *   3. Rewrite the result = VALUE #( ... ) block of get_catalog( ) in the
- *      launchpad app of each area (src/01 -> sample_000, src/00 -> sample_001):
+ *      launchpad app of each area (src/01 -> sample_app_000, src/00 -> sample_app_001):
  *        - groups in folder-number order
  *        - tiles within a group sorted by header, then sub, then app
  *
@@ -27,8 +27,8 @@ const SRC = path.join(__dirname, '..', 'src');
 
 // area (top-level package under src) -> launchpad app file
 const TARGETS = {
-  '01': path.join(SRC, '01', 'z2ui5_cl_sample_000.clas.abap'),
-  '00': path.join(SRC, '00', 'z2ui5_cl_sample_001.clas.abap'),
+  '01': path.join(SRC, '01', 'z2ui5_cl_sample_app_000.clas.abap'),
+  '00': path.join(SRC, '00', 'z2ui5_cl_sample_app_001.clas.abap'),
 };
 
 function walk(dir, out = []) {

--- a/src/00/z2ui5_cl_sample_app_001.clas.abap
+++ b/src/00/z2ui5_cl_sample_app_001.clas.abap
@@ -1,4 +1,4 @@
-CLASS z2ui5_cl_sample_001 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_app_001 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -37,7 +37,7 @@ CLASS z2ui5_cl_sample_001 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_sample_001 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_app_001 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -96,7 +96,7 @@ CLASS z2ui5_cl_sample_001 IMPLEMENTATION.
         navbuttonpress = client->_event_nav_app_leave( )
         shownavbutton  = client->check_app_prev_stack( ) ).
 
-    DATA(url_standard) = |{ client->get( )-s_config-origin }{ client->get( )-s_config-pathname }?app_start=z2ui5_cl_sample_000|.
+    DATA(url_standard) = |{ client->get( )-s_config-origin }{ client->get( )-s_config-pathname }?app_start=z2ui5_cl_sample_app_000|.
     page->header_content( )->button(
         text  = `Basic Samples`
         icon  = `sap-icon://action`

--- a/src/00/z2ui5_cl_sample_app_001.clas.xml
+++ b/src/00/z2ui5_cl_sample_app_001.clas.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>Z2UI5_CL_SAMPLE_001</CLSNAME>
+    <CLSNAME>Z2UI5_CL_SAMPLE_APP_001</CLSNAME>
     <LANGU>E</LANGU>
     <DESCRIPT>abap2UI5 - Samples Overview (restricted)</DESCRIPT>
     <STATE>1</STATE>

--- a/src/01/z2ui5_cl_sample_app_000.clas.abap
+++ b/src/01/z2ui5_cl_sample_app_000.clas.abap
@@ -1,4 +1,4 @@
-CLASS z2ui5_cl_sample_000 DEFINITION PUBLIC.
+CLASS z2ui5_cl_sample_app_000 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES z2ui5_if_app.
@@ -42,7 +42,7 @@ CLASS z2ui5_cl_sample_000 DEFINITION PUBLIC.
 ENDCLASS.
 
 
-CLASS z2ui5_cl_sample_000 IMPLEMENTATION.
+CLASS z2ui5_cl_sample_app_000 IMPLEMENTATION.
 
   METHOD z2ui5_if_app~main.
 
@@ -101,8 +101,8 @@ CLASS z2ui5_cl_sample_000 IMPLEMENTATION.
         navbuttonpress = client->_event_nav_app_leave( )
         shownavbutton  = client->check_app_prev_stack( ) ).
 
-    IF class_exists( `Z2UI5_CL_SAMPLE_001` ) = abap_true.
-      DATA(url_restricted) = |{ client->get( )-s_config-origin }{ client->get( )-s_config-pathname }?app_start=z2ui5_cl_sample_001|.
+    IF class_exists( `Z2UI5_CL_SAMPLE_APP_001` ) = abap_true.
+      DATA(url_restricted) = |{ client->get( )-s_config-origin }{ client->get( )-s_config-pathname }?app_start=z2ui5_cl_sample_app_001|.
       page->header_content( )->button(
           text  = `Extended Samples`
           icon  = `sap-icon://action`

--- a/src/01/z2ui5_cl_sample_app_000.clas.xml
+++ b/src/01/z2ui5_cl_sample_app_000.clas.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>Z2UI5_CL_SAMPLE_000</CLSNAME>
+    <CLSNAME>Z2UI5_CL_SAMPLE_APP_000</CLSNAME>
     <LANGU>E</LANGU>
     <DESCRIPT>abap2UI5 - Samples Overview (extension)</DESCRIPT>
     <STATE>1</STATE>


### PR DESCRIPTION
## Summary
Rename the two launchpad app classes to follow a more explicit naming convention by inserting `_app_` into their class names, improving clarity and consistency across the codebase.

## Changes
- **Class renames:**
  - `z2ui5_cl_sample_000` → `z2ui5_cl_sample_app_000` (extended samples launchpad in `src/01`)
  - `z2ui5_cl_sample_001` → `z2ui5_cl_sample_app_001` (restricted samples launchpad in `src/00`)

- **Updated all references** to the renamed classes:
  - Class definitions and implementations in both `.clas.abap` files
  - Class metadata in `.clas.xml` files
  - Cross-references between launchpads (navigation URLs)
  - Script configuration in `generate-launchpad.js`
  - Documentation in `AGENTS.md` (all references to old class names updated)

## Implementation Details
- Both launchpad classes maintain their original functionality and structure
- Navigation between launchpads continues to work via updated URL parameters
- The generation script correctly maps source areas to their respective launchpad files
- All documentation has been updated to reflect the new naming convention

https://claude.ai/code/session_01LrT22ghP1az6CmxKPoTHTn