### PR TITLE
Rename launchpad workflow to generate_overview_apps

### DIFF
--- a/.github/workflows/generate_overview_apps.yaml
+++ b/.github/workflows/generate_overview_apps.yaml
@@ -1,4 +1,4 @@
-name: launchpad
+name: generate_overview_apps
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  launchpad:
+  generate_overview_apps:
     if: github.ref == 'refs/heads/standard'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -24,14 +24,21 @@ jobs:
     - run: npm ci
     - run: npm run launchpad
 
+    - name: Stamp last run date into README
+      run: |
+        STAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+        sed -i "s|<!-- last-run -->.*<!-- /last-run -->|<!-- last-run -->$STAMP<!-- /last-run -->|" README.md
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:
-        add-paths: src
-        commit-message: Regenerate launchpad
+        add-paths: |
+          src
+          README.md
+        commit-message: Regenerate overview apps
         author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
         committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
-        branch: launchpad/regenerate
+        branch: generate_overview_apps/regenerate
         delete-branch: true
-        title: Regenerate launchpad
-        body: Automated launchpad regeneration.
+        title: Regenerate overview apps
+        body: Automated overview apps regeneration.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 <br>
 [![auto_downport](https://github.com/abap2UI5/samples/actions/workflows/auto_downport.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/auto_downport.yaml)
 [![auto_cloud](https://github.com/abap2UI5/samples/actions/workflows/auto_cloud.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/auto_cloud.yaml)
+[![generate_overview_apps](https://github.com/abap2UI5/samples/actions/workflows/generate_overview_apps.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/generate_overview_apps.yaml)
+
+_generate_overview_apps last run: <!-- last-run -->never<!-- /last-run -->_
 
 
 # abap2UI5-samples


### PR DESCRIPTION
## Summary
Rename the GitHub Actions workflow from "launchpad" to "generate_overview_apps" to better reflect its purpose of generating overview app configurations. This includes updating all workflow references, job names, branch names, and commit messages.

## Key Changes
- Renamed workflow file from `generate_overview_apps.yaml` (already reflected in filename)
- Updated workflow name from `launchpad` to `generate_overview_apps`
- Updated job name from `launchpad` to `generate_overview_apps`
- Updated pull request branch from `launchpad/regenerate` to `generate_overview_apps/regenerate`
- Updated commit and PR messages to reference "overview apps" instead of "launchpad"
- Added workflow badge to README.md
- Added timestamp tracking for last workflow run in README.md with `<!-- last-run -->` markers
- Extended `add-paths` to include `README.md` alongside `src` directory

## Implementation Details
- The workflow now stamps the current UTC date/time into the README.md file on each run
- Uses `sed` to update the last-run timestamp between HTML comment markers
- Maintains all existing functionality while improving naming clarity

https://claude.ai/code/session_018gfqsobHb7xxoWFZWVEftL