### PR TITLE
Fix SplitContainer aggregation handling in demo app 374

### DIFF
--- a/src/01/08/z2ui5_cl_demo_app_374.clas.abap
+++ b/src/01/08/z2ui5_cl_demo_app_374.clas.abap
@@ -68,7 +68,9 @@ CLASS z2ui5_cl_demo_app_374 IMPLEMENTATION.
            target = `_blank`
            href   = `https://sapui5.hana.ondemand.com/sdk/#/entity/sap.m.SplitContainer` ).
 
-    DATA(split) = page->split_container( ).
+    " split_container( ) returns the page instead of the new control, the
+    " aggregations below would end up under the page - create it generically
+    DATA(split) = page->_generic( `SplitContainer` ).
 
     split->master_pages(
         )->page( `Master`


### PR DESCRIPTION
## Summary
Fixed incorrect control instantiation in demo app 374 where `split_container()` was returning the page instead of the new control, causing child aggregations to be added to the wrong parent.

## Changes
- Replaced `page->split_container()` with `page->_generic( 'SplitContainer' )` to properly instantiate the SplitContainer control
- Added clarifying comments explaining why the generic method is needed instead of the fluent API method

## Details
The `split_container()` method was returning the page object rather than the newly created SplitContainer control. This caused all subsequent aggregations (master_pages, detail_pages, etc.) to be incorrectly added to the page instead of the split container. Using the generic `_generic()` method ensures the control is properly created and returned, allowing the fluent chain to work as intended.

https://claude.ai/code/session_01BTVYMeYxntmeJctFCfgVTp