### PR TITLE
Use em instead of ch for link width in overview apps

### DIFF
--- a/src/00/z2ui5_cl_sample_app_000.clas.abap
+++ b/src/00/z2ui5_cl_sample_app_000.clas.abap
@@ -140,7 +140,9 @@ CLASS z2ui5_cl_sample_app_000 IMPLEMENTATION.
 
       prev_base = base.
 
-      DATA(width) = |{ t_blocks[ group = tile-group base = base ]-len + 2 }ch|.
+      " CSSSize does not allow the ch unit - approximate 0.6em per character
+      DATA(len) = t_blocks[ group = tile-group base = base ]-len.
+      DATA(width) = |{ ( ( len + 2 ) * 6 + 9 ) DIV 10 }em|.
       DATA(row) = page->hbox(
           alignitems = `Center`
           wrap       = `Wrap`

--- a/src/01/z2ui5_cl_sample_app_001.clas.abap
+++ b/src/01/z2ui5_cl_sample_app_001.clas.abap
@@ -157,7 +157,9 @@ CLASS z2ui5_cl_sample_app_001 IMPLEMENTATION.
 
       prev_base = base.
 
-      DATA(width) = |{ t_blocks[ group = tile-group base = base ]-len + 2 }ch|.
+      " CSSSize does not allow the ch unit - approximate 0.6em per character
+      DATA(len) = t_blocks[ group = tile-group base = base ]-len.
+      DATA(width) = |{ ( ( len + 2 ) * 6 + 9 ) DIV 10 }em|.
       DATA(row) = page->hbox(
           alignitems = `Center`
           wrap       = `Wrap`


### PR DESCRIPTION
## Summary
Follow-up to #665: the width introduced there used the `ch` unit, which `sap.ui.core.CSSSize` does not accept, so UI5 rejected the value at runtime:

```
"13ch" is of type string, expected sap.ui.core.CSSSize for property "width" of Element sap.m.Link
```

## Changes
- Calculate the link width in `em` instead of `ch` (0.6em per character, rounded up to whole em, keeping the 2-character buffer)
- Applied identically in both overview apps (`z2ui5_cl_sample_app_001` and `z2ui5_cl_sample_app_000`)
- All links of a block still share the same width, so the sub-descriptions stay aligned in one column

## Checks
- `abaplint`: 0 issues
- 702 downport build (`npm run downport` + abaplint): 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qr65e6zfEqoq3hmNASjxc