### PR TITLE
Simplify overview apps workflow to commit directly to main branch

### DIFF
--- a/.github/workflows/generate_overview_apps.yaml
+++ b/.github/workflows/generate_overview_apps.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   generate_overview_apps:
@@ -32,16 +31,14 @@ jobs:
         STAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
         sed -i "s|<!-- last-run -->.*<!-- /last-run -->|<!-- last-run -->$STAMP<!-- /last-run -->|" README.md
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v8
-      with:
-        add-paths: |
-          src
-          README.md
-        commit-message: Regenerate overview apps
-        author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
-        committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
-        branch: generate_overview_apps/regenerate
-        delete-branch: true
-        title: Regenerate overview apps
-        body: Automated overview apps regeneration.
+    - name: Commit and push changes
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add src README.md
+        if git diff --staged --quiet; then
+          echo "No changes to commit."
+        else
+          git commit -m "Regenerate overview apps"
+          git push origin HEAD:standard
+        fi


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow for generating overview apps to commit changes directly to the main branch instead of creating pull requests.

## Key Changes
- Removed `pull-requests: write` permission (no longer needed)
- Replaced `peter-evans/create-pull-request` action with native `git` commands
- Changed workflow to commit directly to the `standard` branch instead of creating a separate PR branch
- Added conditional check to skip commit if there are no changes to commit

## Implementation Details
The workflow now:
1. Configures git user identity for the bot
2. Stages changes to `src` and `README.md`
3. Only commits and pushes if there are actual changes (using `git diff --staged --quiet`)
4. Pushes directly to the `standard` branch via `HEAD:standard`

This simplifies the automation by eliminating the intermediate pull request step while maintaining the same end result of updating the repository with regenerated overview apps.

https://claude.ai/code/session_018Jku7WcrZWpkxR3nFDHufE