### PR TITLE
Make overview app generation a CI check instead of auto-commit

### DIFF
--- a/.github/abaplint/abap_cloud.jsonc
+++ b/.github/abaplint/abap_cloud.jsonc
@@ -10,7 +10,6 @@
     },
     {
       "url": "https://github.com/abap2UI5/abap2UI5",
-      "branch": "claude/ui5-samples-ai-demokit-s5n5sg",
       "folder": "/abap2UI5",
       "files": "/src/**/*.*"
     }

--- a/.github/workflows/generate_overview_apps.yaml
+++ b/.github/workflows/generate_overview_apps.yaml
@@ -1,16 +1,25 @@
 name: generate_overview_apps
 
+# Guards that the two overview apps (get_catalog) are in sync with the folder
+# tree: regenerates them and fails on any diff. standard is a protected branch
+# (changes only via pull request), so CI cannot push fixes back — contributors
+# regenerate the catalogs in their PR instead (see AGENTS.md §4).
+
 on:
+  pull_request:
   push:
     branches: [standard]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: generate_overview_apps-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   generate_overview_apps:
-    if: github.ref == 'refs/heads/standard'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -26,19 +35,9 @@ jobs:
     - run: npm ci
     - run: npm run launchpad
 
-    - name: Stamp last run date into README
+    - name: Verify overview apps are up to date
       run: |
-        STAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
-        sed -i "s|<!-- last-run -->.*<!-- /last-run -->|<!-- last-run -->$STAMP<!-- /last-run -->|" README.md
-
-    - name: Commit and push changes
-      run: |
-        git config user.name 'github-actions[bot]'
-        git config user.email 'github-actions[bot]@users.noreply.github.com'
-        git add src README.md
-        if git diff --staged --quiet; then
-          echo "No changes to commit."
-        else
-          git commit -m "Regenerate overview apps"
-          git push origin HEAD:standard
+        if ! git diff --exit-code -- src; then
+          echo "::error::Overview apps are out of date. Run 'npm run launchpad' and commit the result (see AGENTS.md §4)."
+          exit 1
         fi

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Install this repository and try out over 350 samples. This is the easiest way to
 
 [![generate_overview_apps](https://github.com/abap2UI5/samples/actions/workflows/generate_overview_apps.yaml/badge.svg)](https://github.com/abap2UI5/samples/actions/workflows/generate_overview_apps.yaml)
 
-_generate_overview_apps last run: <!-- last-run -->2026-07-17 08:36 UTC<!-- /last-run -->_
-
 #### Dependencies
 * [abap2UI5](https://github.com/abap2UI5/abap2UI5)
 

--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -13,7 +13,6 @@
     },
     {
       "url": "https://github.com/abap2UI5/abap2UI5",
-      "branch": "claude/ui5-samples-ai-demokit-s5n5sg",
       "folder": "/abap2UI5",
       "files": "/src/**/*.*"
     }


### PR DESCRIPTION
## Summary
Changes the `generate_overview_apps` workflow from automatically committing generated files to the `standard` branch into a CI check that verifies the overview apps are up to date. Contributors must now regenerate and commit the catalogs themselves as part of their pull requests.

## Key Changes
- **Workflow trigger**: Added `pull_request` trigger alongside existing `push` to `standard` branch
- **Permissions**: Reduced from `contents: write` to `contents: read` (no longer pushes commits)
- **Job condition**: Removed `if: github.ref == 'refs/heads/standard'` to run on all triggers
- **Concurrency**: Added concurrency group to cancel in-progress runs on the same ref
- **Verification step**: Replaced commit/push logic with a check that fails if `src/` has uncommitted changes after regeneration
- **README**: Removed the "last run" timestamp line
- **abaplint config**: Removed temporary branch references from both `.github/abaplint/abap_cloud.jsonc` and `abaplint.jsonc`

## Implementation Details
The workflow now:
1. Generates the overview apps via `npm run launchpad`
2. Checks if `src/` has any differences
3. Fails with a clear error message directing contributors to AGENTS.md §4 if regeneration is needed
4. Allows the workflow to pass only when catalogs are already up to date

This enforces the protected branch model where `standard` cannot receive direct commits from CI, ensuring all changes go through pull request review.

https://claude.ai/code/session_01A6f6qCjKEK3syioCzisYqD