### PR TITLE
Remove /XX/ prefix from template binding paths

### DIFF
--- a/src/00/05/z2ui5_cl_demo_app_346.clas.abap
+++ b/src/00/05/z2ui5_cl_demo_app_346.clas.abap
@@ -66,8 +66,8 @@ CLASS z2ui5_cl_demo_app_346 IMPLEMENTATION.
                                                 && `    const m = focusCtrlId.match(/(\d+$)/);`
                                                 && `    const model = z2ui5.oView.getModel() ;`
                                                 && `    model.setProperty("/FOCUSID",focusCtrlId);`
-                                                && `    model.setProperty("/XX/FOCUSCOLUMN",column);`
-                                                && `    model.setProperty("/XX/FOCUSROW",m[1]);`
+                                                && `    model.setProperty("/FOCUSCOLUMN",column);`
+                                                && `    model.setProperty("/FOCUSROW",m[1]);`
                                                 && `  } catch(e){}`
                                                 && `}, true);`
                                                 && ``

--- a/src/01/01/z2ui5_cl_demo_app_173.clas.abap
+++ b/src/01/01/z2ui5_cl_demo_app_173.clas.abap
@@ -55,7 +55,7 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
 
     view->table( client->_bind( mt_data )
       )->columns(
-        )->template_repeat( list = `{template>/XX/MT_LAYOUT}`
+        )->template_repeat( list = `{template>/MT_LAYOUT}`
                             var  = `L0`
           )->column( mergeduplicates = `{L0>MERGE}`
                      visible         = `{L0>VISIBLE}` )->text( `{L0>FNAME}` )->get_parent(
@@ -63,7 +63,7 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
         )->items(
           )->column_list_item(
             )->cells(
-              )->template_repeat( list = `{template>/XX/MT_LAYOUT}`
+              )->template_repeat( list = `{template>/MT_LAYOUT}`
                                   var  = `L1`
                 )->object_identifier( text = `{= '{' + ${L1>FNAME} + '}' }` ).
 
@@ -72,7 +72,7 @@ CLASS Z2UI5_CL_DEMO_APP_173 IMPLEMENTATION.
                   change = client->_event( `CHANGE_FLAG` ) ).
                   view   = view->vbox( ).
 
-    view->template_if( `{template>/XX/MV_FLAG}`
+    view->template_if( `{template>/MV_FLAG}`
       )->template_then(
         )->icon( src   = `sap-icon://accept`
                  color = `green` )->get_parent(

--- a/src/01/01/z2ui5_cl_demo_app_176.clas.abap
+++ b/src/01/01/z2ui5_cl_demo_app_176.clas.abap
@@ -76,7 +76,7 @@ CLASS z2ui5_cl_demo_app_176 IMPLEMENTATION.
     lo_view_nested->shell( )->page( `Nested View`
       )->table( i_client->_bind( mt_data )
       )->columns(
-        )->template_repeat( list = `{template>/XX/MT_LAYOUT}`
+        )->template_repeat( list = `{template>/MT_LAYOUT}`
                             var  = `LO`
           )->column( mergeduplicates = `{LO>MERGE}`
                      visible         = `{LO>VISIBLE}` )->get_parent(
@@ -84,7 +84,7 @@ CLASS z2ui5_cl_demo_app_176 IMPLEMENTATION.
         )->items(
           )->column_list_item(
             )->cells(
-              )->template_repeat( list = `{template>/XX/MT_LAYOUT}`
+              )->template_repeat( list = `{template>/MT_LAYOUT}`
                                   var  = `LO2`
                 )->object_identifier( text = `{= '{' + ${LO2>FNAME} + '}' }` ).
 

--- a/src/01/02/z2ui5_cl_demo_app_461.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_461.clas.abap
@@ -53,9 +53,9 @@ CLASS Z2UI5_CL_DEMO_APP_461 IMPLEMENTATION.
 
       WHEN `MOVE_NODE`.
         " both event args arrive resolved client-side: the binding context
-        " paths of the dragged and the drop target item. The two-way model
-        " prefixes them with /XX/, e.g. /XX/T_NODES/0/NODES/1 (a file) and
-        " /XX/T_NODES/2 (a folder) - so parse from the END of the path
+        " paths of the dragged and the drop target item, e.g.
+        " /T_NODES/0/NODES/1 (a file) and /T_NODES/2 (a folder) - so parse
+        " from the END of the path
         SPLIT client->get_event_arg( ) AT `/` INTO TABLE DATA(lt_drag).
         SPLIT client->get_event_arg( 2 ) AT `/` INTO TABLE DATA(lt_drop).
         DATA(lv_drag_lines) = lines( lt_drag ).


### PR DESCRIPTION
## Summary
Remove the `/XX/` prefix from all template binding paths across multiple demo applications. This simplifies the binding syntax by using direct root-level paths instead of the prefixed variant.

## Changes
- **z2ui5_cl_demo_app_173**: Updated 3 template binding paths from `/XX/MT_LAYOUT` and `/XX/MV_FLAG` to their unprefixed equivalents
- **z2ui5_cl_demo_app_176**: Updated 2 template binding paths from `/XX/MT_LAYOUT` to `/MT_LAYOUT` in nested view implementation
- **z2ui5_cl_demo_app_346**: Updated 2 model property paths in JavaScript code from `/XX/FOCUSCOLUMN` and `/XX/FOCUSROW` to their unprefixed versions
- **z2ui5_cl_demo_app_461**: Updated code comments to reflect that binding paths no longer include the `/XX/` prefix (e.g., `/T_NODES/0/NODES/1` instead of `/XX/T_NODES/0/NODES/1`)

## Implementation Details
The changes maintain functional equivalence while standardizing on the simpler binding path format. All affected bindings are in template contexts (template_repeat, template_if) and model property setters.

https://claude.ai/code/session_01BRbBrfS2hPi9EFQqjjgfHX