### PR TITLE
Simplify control_by_id API: remove view parameter from t_arg

### DIFF
--- a/src/01/01/z2ui5_cl_demo_app_447.clas.abap
+++ b/src/01/01/z2ui5_cl_demo_app_447.clas.abap
@@ -46,17 +46,16 @@ CLASS z2ui5_cl_demo_app_447 IMPLEMENTATION.
 
     CASE client->get( )-event.
 
-      " t_arg is positional: id, view (`` = global lookup), method, params
+      " t_arg is positional: id, method, params (the view defaults to
+      " cs_view-main and can be omitted for a main-view control)
       WHEN `FOCUS`.
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
                                   t_arg = VALUE #( ( `nameInput` )
-                                                   ( `` )
                                                    ( `focus` ) ) ).
 
       WHEN `SCROLL`.
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
                                   t_arg = VALUE #( ( `bigTable` )
-                                                   ( `` )
                                                    ( `scrollToIndex` )
                                                    ( `25` ) ) ).
 

--- a/src/01/02/z2ui5_cl_demo_app_088.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_088.clas.abap
@@ -64,7 +64,7 @@ CLASS z2ui5_cl_demo_app_088 IMPLEMENTATION.
 
     page->icon_tab_header( selectedkey                   = client->_bind( mv_selected_key )
                                                   select = client->_event_client( val   = client->cs_event-control_by_id
-                                                                                  t_arg = VALUE #( ( `NavCon` ) ( `MAIN` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
+                                                                                  t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
                                                   mode   = `Inline`
                                   )->items(
                                     )->icon_tab_filter( key  = `page1`

--- a/src/01/02/z2ui5_cl_demo_app_170.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_170.clas.abap
@@ -29,7 +29,8 @@ CLASS z2ui5_cl_demo_app_170 IMPLEMENTATION.
 
     DATA(content) = dialog->icon_tab_bar( selectedkey        = client->_bind( mv_selected_key )
                                                   select     = client->_event_client( val   = client->cs_event-control_by_id
-                                                                                      t_arg = VALUE #( ( `NavCon` ) ( `POPUP` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
+                                                                                      view  = client->cs_view-popup
+                                                                                      t_arg = VALUE #( ( `NavCon` ) ( `to` ) ( `${$parameters>/selectedKey}` ) ) )
                                                   headermode = `Inline`
                                                   expanded   = abap_true
                                                   expandable = abap_false

--- a/src/01/02/z2ui5_cl_demo_app_202.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_202.clas.abap
@@ -84,13 +84,14 @@ CLASS Z2UI5_CL_DEMO_APP_202 IMPLEMENTATION.
       WHEN `STEP22` OR `STEP23`.
         " the original wizard flow (discardProgress + setNextStep) as two
         " generic whitelisted control calls - t_arg is positional:
-        " id, view, method, params (the step params are control ids)
+        " id, method, params (the step params are control ids; the view
+        " defaults to cs_view-main)
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-control_by_id
-            t_arg = VALUE #( ( `wiz` ) ( `MAIN` ) ( `discardProgress` ) ( `STEP2` ) ) ).
+            t_arg = VALUE #( ( `wiz` ) ( `discardProgress` ) ( `STEP2` ) ) ).
         client->follow_up_action(
             val   = z2ui5_if_client=>cs_event-control_by_id
-            t_arg = VALUE #( ( `STEP2` ) ( `MAIN` ) ( `setNextStep` ) ( client->get( )-event ) ) ).
+            t_arg = VALUE #( ( `STEP2` ) ( `setNextStep` ) ( client->get( )-event ) ) ).
 
     ENDCASE.
     client->view_model_update( ).

--- a/src/01/02/z2ui5_cl_demo_app_448.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_448.clas.abap
@@ -36,11 +36,11 @@ CLASS z2ui5_cl_demo_app_448 IMPLEMENTATION.
       WHEN `TOGGLE`.
         " invert the mirrored state and call the whitelisted setExpanded on
         " the panel - client-side, after the response renders, no rebuild.
-        " t_arg is positional: id, view (`` = global lookup), method, params
+        " t_arg is positional: id, method, params (the view defaults to
+        " cs_view-main and can be omitted for a main-view control)
         expanded = xsdbool( expanded = abap_false ).
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
                                   t_arg = VALUE #( ( `demoPanel` )
-                                                   ( `` )
                                                    ( `setExpanded` )
                                                    ( CONV string( expanded ) ) ) ).
 

--- a/src/01/02/z2ui5_cl_demo_app_449.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_449.clas.abap
@@ -34,10 +34,10 @@ CLASS z2ui5_cl_demo_app_449 IMPLEMENTATION.
       WHEN `OPEN`.
         " open the popup-mode PDFViewer via the whitelisted open method -
         " the viewer brings its own dialog and close button.
-        " t_arg is positional: id, view (`` = global lookup), method
+        " t_arg is positional: id, method (the view defaults to cs_view-main
+        " and can be omitted for a main-view control)
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
                                   t_arg = VALUE #( ( `demoPdf` )
-                                                   ( `` )
                                                    ( `open` ) ) ).
 
     ENDCASE.

--- a/src/01/02/z2ui5_cl_demo_app_465.clas.abap
+++ b/src/01/02/z2ui5_cl_demo_app_465.clas.abap
@@ -35,10 +35,10 @@ CLASS z2ui5_cl_demo_app_465 IMPLEMENTATION.
         " toggle the popover open/closed, anchored to the pressed button's DOM
         " ref - the whitelisted toggleBy opens it if closed, closes it if open
         " (the controller pattern oPopover.openBy(oButton) / oPopover.close()).
-        " t_arg is positional: id, view (`` = global lookup), method, anchor id
+        " t_arg is positional: id, method, anchor id (the view defaults to
+        " cs_view-main and can be omitted for a main-view control)
         client->follow_up_action( val   = z2ui5_if_client=>cs_event-control_by_id
                                   t_arg = VALUE #( ( `demoPopover` )
-                                                   ( `` )
                                                    ( `toggleBy` )
                                                    ( client->get_event_arg( ) ) ) ).
 


### PR DESCRIPTION
## Summary
Refactored the `control_by_id` event API to remove the explicit view parameter from the positional `t_arg` array. The view now defaults to `cs_view-main` and can be specified separately via an optional `view` parameter when needed.

## Key Changes
- **API Simplification**: Removed the view identifier (second position) from `t_arg` in all `control_by_id` follow-up action calls across demo apps 202, 447, 448, 449, and 465
  - Old format: `t_arg = VALUE #( ( id ) ( view ) ( method ) ( params... ) )`
  - New format: `t_arg = VALUE #( ( id ) ( method ) ( params... ) )`

- **Explicit View Parameter**: Updated demo app 170 to use the new `view` parameter explicitly when targeting non-main views (e.g., `view = client->cs_view-popup`)

- **Documentation Updates**: Clarified inline comments across all modified files to reflect that:
  - View defaults to `cs_view-main`
  - View parameter can be omitted for main-view controls
  - `t_arg` is now positional with id, method, and params only

## Implementation Details
- Demo app 088: Removed `MAIN` view identifier from navigation control call
- Demo app 170: Migrated from positional view parameter to explicit `view` parameter for popup view targeting
- All other apps: Simplified `t_arg` arrays by removing empty string (`""`) or explicit view identifiers
- Comments updated to document the new API contract

https://claude.ai/code/session_01Ar8FTqFRTaZ9r5jcje9J9n