### PR TITLE
Regenerate overview catalogs after app 468 moved to src/00/00

### DIFF
--- a/src/00/z2ui5_cl_sample_app_g01.clas.abap
+++ b/src/00/z2ui5_cl_sample_app_g01.clas.abap
@@ -214,6 +214,7 @@ CLASS z2ui5_cl_sample_app_g01 IMPLEMENTATION.
   METHOD get_catalog.
 
     result = VALUE #(
+      ( group = `extended` header = `EXPERIMENTAL` sub = `Navigation - Routing modes` app = `z2ui5_cl_demo_app_468` )
       ( group = `extended` header = `EXPERIMENTAL` sub = `Smart Multi Input` app = `z2ui5_cl_demo_app_319` )
       ( group = `extended` header = `EXPERIMENTAL` sub = `Smart Table and Variants` app = `z2ui5_cl_demo_app_313` )
       ( group = `extended` header = `EXPERIMENTAL` sub = `Switch default Model` app = `z2ui5_cl_demo_app_314` )

--- a/src/01/z2ui5_cl_demo_app_g00.clas.abap
+++ b/src/01/z2ui5_cl_demo_app_g00.clas.abap
@@ -222,7 +222,6 @@ CLASS z2ui5_cl_demo_app_g00 IMPLEMENTATION.
       ( group = `Basic I` header = `Event` sub = `Additional Infos with t_args` app = `z2ui5_cl_demo_app_167` )
       ( group = `Basic I` header = `Event` sub = `Facet Filter T_arg with Objects` app = `z2ui5_cl_demo_app_197` )
       ( group = `Basic I` header = `Event` sub = `Handle events & change the view` app = `z2ui5_cl_demo_app_004` )
-      ( group = `Basic I` header = `EXPERIMENTAL` sub = `Navigation - Routing modes` app = `z2ui5_cl_demo_app_468` )
       ( group = `Basic I` header = `Focus` sub = `Focus Aggregations` app = `z2ui5_cl_demo_app_421` )
       ( group = `Basic I` header = `Focus` sub = `Jump with the focus (A)` app = `z2ui5_cl_demo_app_189` )
       ( group = `Basic I` header = `Focus` sub = `Set Focus in Textfield (A)` app = `z2ui5_cl_demo_app_133` )


### PR DESCRIPTION
## Summary

Fixes the failing `generate_overview_apps` check on `standard`.

Commit 7a028fe ("reassign package") moved `z2ui5_cl_demo_app_468` from
`src/01/01` to `src/00/00`, but did not regenerate the two `get_catalog( )`
tables. Per AGENTS.md §4 the catalogs are a generated mirror of the folder
tree, and the workflow enforces that by running `npm run launchpad` and
failing on any diff — so `standard` has been red since that commit.

This PR contains only the generator output. The package reassignment itself
already happened in 7a028fe and is not changed here.

## Changes

Produced by `npm run launchpad`, not hand-edited:

- `src/01/z2ui5_cl_demo_app_g00.clas.abap` — tile removed (was group `Basic I`)
- `src/00/z2ui5_cl_sample_app_g01.clas.abap` — tile added (group `extended`)

The new group matches the CTEXT of the app's new subpackage `src/00/00`.

## Verification

- `npm run launchpad` — now diff-free
- `npx abaplint` — 0 issues, 743 files analyzed
- `npm run check:agents` — tree matches src/ (21 subpackages)

## Note

Not changed here, but worth a look: AGENTS.md §2 rule 6 maps
"Experimental / work-in-progress" to `00/07` rather than `00/00`. The other
`EXPERIMENTAL` apps (319, 313, 314) already sit in `00/00`, so the placement is
consistent with what's there — flagging it rather than overriding it.