### PR TITLE
Handle browser navigation restore in demo app 469

### DIFF
--- a/src/01/01/z2ui5_cl_demo_app_469.clas.abap
+++ b/src/01/01/z2ui5_cl_demo_app_469.clas.abap
@@ -4,6 +4,11 @@
 "! history entry, so the browser Back button returns to the hub it came from.
 "! This app only shows what to do next; it is a hidden helper (never listed on
 "! its own in the overview).
+"!
+"! In mode keep the browser Forward button (or a reload/bookmark of the route)
+"! restores this app from its draft and enters main( ) via
+"! check_on_navigated( ) - the view must be rendered again there, or the
+"! browser keeps showing the hub it navigated away from.
 CLASS z2ui5_cl_demo_app_469 DEFINITION PUBLIC.
 
   PUBLIC SECTION.
@@ -27,6 +32,12 @@ CLASS z2ui5_cl_demo_app_469 IMPLEMENTATION.
     me->client = client.
 
     IF client->check_on_init( ).
+      view_display( ).
+
+    ELSEIF client->check_on_navigated( ).
+      " browser Forward / reload / bookmark restored this app from its draft
+      " (routing mode keep) - the state survived, only the view must be
+      " rendered again
       view_display( ).
     ENDIF.
 


### PR DESCRIPTION
## Summary
Add support for restoring demo app 469 when the browser Forward button, reload, or bookmark navigation occurs in routing mode `keep`. The app now properly re-renders the view when restored from draft state.

## Changes
- **Documentation**: Expanded class-level comments to explain the behavior when the browser Forward button or reload restores the app from its draft in routing mode `keep`
- **Navigation handling**: Added `check_on_navigated()` condition in `main()` method to detect when the app is restored via browser navigation
- **View re-rendering**: Call `view_display()` when navigated back to the app to ensure the UI is properly rendered, even though the application state is preserved

## Implementation Details
The change follows the pattern where:
1. `check_on_init()` handles initial app load and displays the view
2. `check_on_navigated()` handles restoration from draft when user navigates back via browser controls
3. Both paths call `view_display()` to ensure the view is rendered, since the browser may still be showing the previous page until the view is refreshed

https://claude.ai/code/session_016USY5fyCFzP56BZTFz6iTM