### PR TITLE
Regenerate the overview apps after the merge instead of blocking the PR

### DIFF
--- a/.github/workflows/auto_cloud.yaml
+++ b/.github/workflows/auto_cloud.yaml
@@ -6,6 +6,9 @@ name: auto_cloud
 on:
   push:
     branches: [standard]
+  # generate_overview_apps dispatches this after pushing regenerated catalogs:
+  # its push carries the GITHUB_TOKEN and therefore starts no run by itself.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/auto_downport.yaml
+++ b/.github/workflows/auto_downport.yaml
@@ -6,6 +6,9 @@ name: auto_downport
 on:
   push:
     branches: [standard]
+  # generate_overview_apps dispatches this after pushing regenerated catalogs:
+  # its push carries the GITHUB_TOKEN and therefore starts no run by itself.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/generate_overview_apps.yaml
+++ b/.github/workflows/generate_overview_apps.yaml
@@ -9,16 +9,17 @@ name: generate_overview_apps
 # workflow regenerates the catalogs on standard and pushes the result back, so
 # standard is self-healing.
 #
-# The push uses the deploy key ACTION_KEY_SAMPLES (same pattern as
-# ACTION_KEY_FRONTEND / ACTION_KEY_LOCAL in abap2UI5/abap2UI5), for two
-# reasons: standard is protected, so the pushing actor needs a bypass entry in
-# its branch ruleset, and a push with the default GITHUB_TOKEN would not
-# re-trigger auto_cloud / auto_downport — the cloud and 702 branches would keep
-# the stale catalog until the next unrelated push. The run triggered by the
-# push itself sees no diff and stops, so this does not loop.
+# standard is protected, so the push only works once the GitHub Actions app is
+# a bypass actor on its branch ruleset. Until then the job fails on a diff,
+# which is the previous behaviour.
 #
-# Without the secret configured the workflow only verifies and fails on a diff,
-# which is the previous behaviour — so it is safe before the key exists.
+# A push made with GITHUB_TOKEN does not start further workflow runs (GitHub's
+# guard against recursive workflows), so the rebuilds of the cloud and 702
+# branches are dispatched explicitly below — workflow_dispatch is exempt from
+# that restriction. Without it those branches would keep the stale catalog
+# until the next unrelated push to standard.
+#
+# The push does not re-run this workflow either, so this cannot loop.
 
 on:
   push:
@@ -26,7 +27,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  actions: write
 
 concurrency:
   group: generate_overview_apps
@@ -39,10 +41,6 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        # Empty when the secret is not configured — checkout then falls back to
-        # the default token and the workflow stays a read-only guard.
-        ssh-key: ${{ secrets.ACTION_KEY_SAMPLES }}
 
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -55,7 +53,7 @@ jobs:
 
     - name: Sync overview apps
       env:
-        CAN_PUSH: ${{ secrets.ACTION_KEY_SAMPLES != '' }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if git diff --quiet -- src; then
           echo "Overview apps are up to date."
@@ -64,14 +62,19 @@ jobs:
 
         git diff --stat -- src
 
-        if [ "$CAN_PUSH" != "true" ]; then
-          echo "::error::Overview apps are out of date and no deploy key is configured. Run 'npm run launchpad' and commit the result (see AGENTS.md §4)."
-          exit 1
-        fi
-
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add -- src
         git commit -m "Regenerate overview apps from ${GITHUB_SHA}"
-        git push origin HEAD:refs/heads/standard
-        echo "::notice::Overview apps were out of date — regenerated and pushed to standard."
+
+        if ! git push origin HEAD:refs/heads/standard; then
+          echo "::error::Could not push the regenerated overview apps. Add the GitHub Actions app as a bypass actor on the standard branch ruleset, or run 'npm run launchpad' and commit the result (see AGENTS.md §4)."
+          exit 1
+        fi
+
+        # This push started no workflow run, so the branch rebuilds that
+        # normally react to a push on standard have to be triggered by hand.
+        gh workflow run auto_cloud.yaml --ref standard
+        gh workflow run auto_downport.yaml --ref standard
+
+        echo "::notice::Overview apps were out of date — regenerated, pushed to standard and the cloud / 702 rebuilds dispatched."

--- a/.github/workflows/generate_overview_apps.yaml
+++ b/.github/workflows/generate_overview_apps.yaml
@@ -2,24 +2,25 @@ name: generate_overview_apps
 
 # Keeps the two overview apps (get_catalog) in sync with the folder tree.
 #
-# On a pull request from a branch of this repository the workflow regenerates
-# the catalogs and pushes the result into the PR branch, so a contributor who
-# forgot `npm run launchpad` does not have to push a follow-up commit. The push
-# uses the deploy key ACTION_KEY_SAMPLES (same pattern as ACTION_KEY_FRONTEND /
-# ACTION_KEY_LOCAL in abap2UI5/abap2UI5) — pushing with the default GITHUB_TOKEN
-# would not re-trigger the other checks, which would leave the new commit
-# unverified. The follow-up run sees no diff and finishes green.
+# The catalogs are generated entirely from the folder tree and the class
+# descriptions, so they are not a review concern and must never hold up a pull
+# request — this workflow deliberately does not run on pull_request. A branch
+# that adds or moves samples can be merged as is; right after the merge this
+# workflow regenerates the catalogs on standard and pushes the result back, so
+# standard is self-healing.
 #
-# Everywhere the push cannot happen — fork pull requests (no secrets), and
-# pushes to the protected branch standard — the workflow stays a pure guard and
-# fails on any diff. Without the secret configured it behaves exactly that way
-# for every event, so it is safe before the key exists.
+# The push uses the deploy key ACTION_KEY_SAMPLES (same pattern as
+# ACTION_KEY_FRONTEND / ACTION_KEY_LOCAL in abap2UI5/abap2UI5), for two
+# reasons: standard is protected, so the pushing actor needs a bypass entry in
+# its branch ruleset, and a push with the default GITHUB_TOKEN would not
+# re-trigger auto_cloud / auto_downport — the cloud and 702 branches would keep
+# the stale catalog until the next unrelated push. The run triggered by the
+# push itself sees no diff and stops, so this does not loop.
 #
-# Contributors are still expected to regenerate the catalogs themselves
-# (AGENTS.md §4); this is the safety net, not the intended workflow.
+# Without the secret configured the workflow only verifies and fails on a diff,
+# which is the previous behaviour — so it is safe before the key exists.
 
 on:
-  pull_request:
   push:
     branches: [standard]
   workflow_dispatch:
@@ -28,8 +29,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: generate_overview_apps-${{ github.ref }}
-  cancel-in-progress: true
+  group: generate_overview_apps
+  cancel-in-progress: false
 
 jobs:
   generate_overview_apps:
@@ -39,12 +40,9 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        # For a pull request from this repository check out the head branch
-        # itself instead of the merge commit, so the regenerated catalogs can be
-        # committed onto it. Fork pull requests and pushes fall back to the
-        # default checkout (empty inputs), where nothing is pushed anyway.
-        ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || '' }}
-        ssh-key: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.ACTION_KEY_SAMPLES || '' }}
+        # Empty when the secret is not configured — checkout then falls back to
+        # the default token and the workflow stays a read-only guard.
+        ssh-key: ${{ secrets.ACTION_KEY_SAMPLES }}
 
     - name: Set up Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -57,8 +55,7 @@ jobs:
 
     - name: Sync overview apps
       env:
-        CAN_PUSH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && secrets.ACTION_KEY_SAMPLES != '' }}
-        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        CAN_PUSH: ${{ secrets.ACTION_KEY_SAMPLES != '' }}
       run: |
         if git diff --quiet -- src; then
           echo "Overview apps are up to date."
@@ -68,13 +65,13 @@ jobs:
         git diff --stat -- src
 
         if [ "$CAN_PUSH" != "true" ]; then
-          echo "::error::Overview apps are out of date. Run 'npm run launchpad' and commit the result (see AGENTS.md §4)."
+          echo "::error::Overview apps are out of date and no deploy key is configured. Run 'npm run launchpad' and commit the result (see AGENTS.md §4)."
           exit 1
         fi
 
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add -- src
-        git commit -m 'Regenerate overview apps'
-        git push origin "HEAD:refs/heads/${HEAD_REF}"
-        echo "::notice::Overview apps were out of date — regenerated and pushed to ${HEAD_REF}."
+        git commit -m "Regenerate overview apps from ${GITHUB_SHA}"
+        git push origin HEAD:refs/heads/standard
+        echo "::notice::Overview apps were out of date — regenerated and pushed to standard."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,13 @@ extend it.
 **Treat the two `get_catalog( )` tables as a generated mirror of the folder
 tree, never as free-form data.** Whenever you add, remove, or move a sample —
 or move a whole subpackage between `src/00` and `src/01`, or change a class's
-description — you **must** regenerate the affected catalog(s) in the same change.
+description — regenerate the affected catalog(s) in the same change.
+
+Stale catalogs never block a pull request: the `generate_overview_apps`
+workflow does not run on `pull_request`. It runs after the merge, regenerates
+the catalogs on `standard` and pushes the result back, so `standard` is
+self-healing. Regenerate them yourself anyway — it keeps the diff reviewable
+and saves the extra bot commit.
 
 ### Regenerate with the generator
 
@@ -193,11 +199,6 @@ npx abaplint           # must report 0 issues
 
 `scripts/generate-launchpad.js` implements every rule below. Edit the script (not
 the generated ABAP) if a rule changes.
-
-The `generate_overview_apps` workflow is the safety net, not a substitute: on a
-pull request from a branch of this repository it regenerates the catalogs and
-pushes the result into the PR branch. Regenerate them yourself anyway — on fork
-pull requests and on `standard` the workflow only guards and fails on any diff.
 
 ### Tile schema
 

--- a/src/00/z2ui5_cl_sample_app_g01.clas.abap
+++ b/src/00/z2ui5_cl_sample_app_g01.clas.abap
@@ -290,6 +290,7 @@ CLASS z2ui5_cl_sample_app_g01 IMPLEMENTATION.
       ( group = `restricted - experimental` header = `Navigation` sub = `push state` app = `z2ui5_cl_demo_app_322` )
       ( group = `restricted - experimental` header = `Navigation with app state change v1 and locking` sub = `` app = `z2ui5_cl_demo_app_350` )
       ( group = `restricted - experimental` header = `popups` sub = `p13n Dialog` app = `z2ui5_cl_demo_app_090` )
+      ( group = `restricted - experimental` header = `Set Cursor Test` sub = `` app = `z2ui5_cl_demo_app_443` )
       ( group = `restricted - experimental` header = `Storage` sub = `Store data inside localStorage or sessionStorage` app = `z2ui5_cl_demo_app_327` )
       ( group = `restricted - experimental` header = `ViewSettingsDialog` sub = `` app = `z2ui5_cl_demo_app_099` )
       ( group = `obsolet` header = `Download CSV` sub = `Export Table as CSV` app = `z2ui5_cl_demo_app_057` )


### PR DESCRIPTION
## Summary

The overview catalogs are generated from the folder tree and the class descriptions, so a stale catalog says nothing about the quality of a change — it only forced a mechanical follow-up commit before a branch could be merged. `generate_overview_apps` now runs **after** the merge instead of on the pull request, so a branch that adds or moves samples can be merged as is and `standard` heals itself.

This also fixes the current red `standard`: #701 was merged without the catalog update, so the workflow has been failing on `standard` since (runs for #701 and #703).

## Changes

**`generate_overview_apps` no longer runs on `pull_request`.** It runs on push to `standard`, regenerates the catalogs there and pushes the result back with the default `GITHUB_TOKEN`. That push starts no workflow run, so this does not loop.

**The cloud and 702 rebuilds are dispatched explicitly.** A push made with `GITHUB_TOKEN` does not start further workflow runs — GitHub's guard against recursive workflows — so `auto_cloud` and `auto_downport` would not react to the bot commit and the `cloud` and `702` branches would keep the stale catalog until the next unrelated push. `workflow_dispatch` is exempt from that restriction, so the job triggers both after pushing; each gains a `workflow_dispatch` trigger for that.

**Adds the missing tile for sample 443** so `standard` is green again immediately.

**`AGENTS.md` §4** now states that a stale catalog never blocks a pull request, while still recommending that contributors regenerate — it keeps the diff reviewable and saves the extra bot commit.

## Follow-up needed to activate

`standard` is protected, so the push only works once the **GitHub Actions app is a bypass actor on the `standard` branch ruleset**. That is the only manual step. Until it is configured the job fails on a diff with an actionable message, which is exactly the previous behaviour — nothing breaks on merge.

An earlier revision of this branch used a deploy key. It turned out to buy only the workflow re-triggering, which `workflow_dispatch` covers, so the secret, its rollover and the caveat that deploy keys cannot be bypass actors under classic branch protection are all gone.

## Verification

- `npx abaplint` — 0 issues across 719 files
- `node scripts/check-agents-structure.js` — passes
- `npm run launchpad` produces no further diff
- All three workflow files parse; triggers and permissions are as intended
- The sync step was exercised against a scratch repository: no diff → exit 0, nothing dispatched; diff → commit pushed to `standard` and both rebuilds dispatched; diff with the push rejected (simulating the missing ruleset bypass) → exit 1 with the actionable message and no dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cpu46KEg8yScnPEVUKS8fL