### PR TITLE
Document ABAP Doc positioning and HTML escaping rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,6 +416,8 @@ manually or via editor tooling that the above rules are met.
       data_update( ).
     ENDIF.
     ```
+- **ABAP Doc (`"!`) position** — not caught by `abaplint`, but the extended check (SLIN/ATC) reports "ABAP Doc comment is in the wrong position": a `"!` block must sit directly before the one declaration it documents. Inside a chained statement (`TYPES: BEGIN OF …`) that means directly before the component, *within* the chain. It is never allowed inside a `METHODS` parameter list — document parameters in the method's own doc block above the `METHODS` keyword via `"! @parameter <name> | <text>`. A plain `"` comment (no `!`) is fine anywhere.
+- ABAP Doc is parsed as HTML: escape a literal `<`, `>` or `&` as `&lt;`, `&gt;`, `&amp;`.
 - Always run `abaplint` after every change. It must report 0 issues before committing.
 - Before starting app development, read all active rules in `abaplint.jsonc` and follow them throughout.
 


### PR DESCRIPTION
## Summary
Added clarification to AGENTS.md regarding ABAP Doc (`"!`) comment positioning rules and HTML escaping requirements that are enforced by extended checks (SLIN/ATC) but not caught by abaplint.

## Changes
- **ABAP Doc positioning guidance**: Documented that `"!` blocks must sit directly before the declaration they document, with specific rules for chained statements and method parameter lists. Parameters should be documented via `@parameter` tags in the method's doc block above `METHODS`, not in the parameter list itself.
- **HTML escaping requirement**: Added note that ABAP Doc is parsed as HTML, requiring literal `<`, `>`, and `&` characters to be escaped as `&lt;`, `&gt;`, and `&amp;` respectively.

## Details
These rules are part of the extended ABAP code quality checks (SLIN/ATC) and complement the abaplint rules already documented in AGENTS.md. The guidance clarifies common pitfalls when writing ABAP Doc comments and ensures consistency across the codebase.

https://claude.ai/code/session_017HrqAXuqw7HZnUZ7KM1yd8