### PR TITLE
Clarify abaplint config handling and simplify downport script

### DIFF
--- a/.github/workflows/publish-branch.yaml
+++ b/.github/workflows/publish-branch.yaml
@@ -49,6 +49,12 @@ jobs:
       if: inputs.do_downport
       run: npm run downport
 
+    # The release-specific config is passed explicitly and never copied over
+    # the root abaplint.jsonc: the abaplint GitHub App picks the root config up
+    # on the derived branch, and it resolves dependencies from the installed
+    # repository's default branch - the `branch` field is a CLI feature. A v702
+    # root config there would check the downported samples against the
+    # un-downported abap2UI5@main. See AGENTS.md section 2.
     - name: Lint ${{ inputs.branch }} content
       run: npx abaplint ${{ inputs.lint_config }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,18 @@ The split is driven directly by the CI builds:
 | `abap-cloud`       | `rm -r src/01` → `abaplint abap_cloud.jsonc`    | ✅ | ❌ |
 | `abap-702`         | `npm run downport` (does `rm -rf src/01`) → `abaplint abap_702.jsonc` | ✅ | ❌ |
 
+The same two transformations produce the derived branches `cloud` and `702`
+(`publish-cloud` / `publish-702`, both via `publish-branch`). Those branches
+carry the root `abaplint.jsonc` of `standard` unchanged — the release-specific
+configs stay under `.github/abaplint/` and are passed to abaplint explicitly.
+Copying `abap_702.jsonc` over the root config would make the abaplint **GitHub
+App** lint the derived branch at syntax `v702`: the app resolves a dependency
+from the installed repository's default branch and ignores the `branch` field,
+so it would check the downported samples against the *un*-downported framework
+in `abap2UI5/abap2UI5@main` and report every type declared there with
+`WITH EMPTY KEY` as unknown. The 7.02 check itself is not lost — it runs in
+`abap-702` on every pull request, and again in `publish-branch` before the push.
+
 **Consequence of the rule:**
 
 - **`src/02` ("basic")** — a sample may only live here if it is **ABAP Cloud

--- a/README.md
+++ b/README.md
@@ -15,9 +15,30 @@
 
 # abap2UI5-samples
 
-Install this repository and try out over 350 samples. This is the easiest way to learn abap2UI5 development.
+More than 330 ready-to-run apps for [abap2UI5](https://github.com/abap2UI5/abap2UI5) — from a two-line Hello World to 1:1 rebuilds of the UI5 demo kit. Install them, click through, read the source: the fastest way to learn abap2UI5 development.
 
+#### Installation
 
-#### Issues
+1. Install [abap2UI5](https://github.com/abap2UI5/abap2UI5) first — this repository ships apps, not the framework.
+2. Pull it with abapGit, using the branch that matches your system:
 
-For bug reports or feature requests, please open an issue in the [abap2UI5 repository.](https://github.com/abap2UI5/abap2UI5/issues)
+   | Branch     | System                                        | Content                              |
+   |------------|-----------------------------------------------|--------------------------------------|
+   | `standard` | on-premise, NW 7.50+                          | everything                           |
+   | `cloud`    | ABAP Cloud, BTP, S/4HANA Cloud                | cloud-ready subset                   |
+   | `702`      | NW 7.02 – 7.4x                                | same subset, downported              |
+
+3. Run `Z2UI5_CL_SMP_APP_000` — the overview app linking every sample of the portable set.
+
+`cloud` and `702` are generated from `standard` on every push; never commit to them directly.
+
+#### What's inside
+
+* **`src/02` "basic"** — cloud-ready, downportable and plain OpenUI5 1.71: framework basics, actions and custom controls, plus the control library rebuilt per UI5 library (`sap.m`, `sap.f`, `sap.uxap`, …). Present on every branch.
+* **`src/01` "restricted"** — everything with a catch: SAPUI5-only controls, features newer than UI5 1.71, on-premise-only ABAP, Fiori Launchpad or OData, plus experimental and obsolete apps. Stripped from `cloud` and `702`.
+
+Layout, naming and code conventions are documented in [AGENTS.md](AGENTS.md) — read it before contributing.
+
+#### Contributing & Issues
+
+Pull requests are welcome, see [CONTRIBUTING.md](CONTRIBUTING.md). For bug reports or feature requests, please open an issue in the [abap2UI5 repository.](https://github.com/abap2UI5/abap2UI5/issues)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "rename": "abaplint .github/abaplint/rename_test.jsonc --rename",
     "check:agents": "node scripts/check-agents-structure.js",
     "syfixes": "find . -type f -name '*.abap' -exec sed -i -e 's/ RAISE EXCEPTION TYPE cx_sy_itab_line_not_found/ ASSERT 1 = 0/g' {} + ",
-    "abaplintpathfix": "sed -i 's|\"files\": \"/\\.\\.\\/\\.\\.\\/src\\/\\*\\*\\/\\*\\.\\*\"|\"files\": \"/src/**/*.*\"|g' abaplint.jsonc",
-    "downport": "rm -rf src/01 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes && cp -f .github/abaplint/abap_702.jsonc abaplint.jsonc && npm run abaplintpathfix"
+    "downport": "rm -rf src/01 && abaplint --fix .github/abaplint/abap_702.jsonc && npm run syfixes"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

This PR improves documentation of the CI/CD pipeline's abaplint configuration strategy and simplifies the downport script by removing unnecessary file manipulation steps.

## Key Changes

- **README.md**: Expanded with comprehensive installation instructions, branch selection table, content organization overview, and contribution guidelines
- **AGENTS.md**: Added detailed explanation of how release-specific abaplint configs are handled in derived branches (`cloud` and `702`), clarifying why the root `abaplint.jsonc` is never overwritten and how the abaplint GitHub App resolves dependencies
- **publish-branch.yaml**: Added clarifying comments about the abaplint config strategy and why release-specific configs are passed explicitly rather than copied to root
- **package.json**: Simplified the `downport` script by removing the `abaplintpathfix` step and `cp` command — the root `abaplint.jsonc` is no longer modified during downporting, keeping the derived branches' configs clean and preventing GitHub App linting issues

## Implementation Details

The key insight documented here is that the abaplint GitHub App resolves dependencies from the installed repository's default branch and ignores the `branch` field (a CLI-only feature). By keeping the root config unchanged on derived branches and passing release-specific configs explicitly via CLI, we ensure the GitHub App checks downported samples against the correct framework version without false positives.

https://claude.ai/code/session_01KxgJM7yvCdWrRLkZVXtE7c