### PR TITLE
Refactor WebSocket app to use custom control instead of JS

### DIFF
--- a/src/01/02/z2ui5_cl_smp_app_489.clas.abap
+++ b/src/01/02/z2ui5_cl_smp_app_489.clas.abap
@@ -4,21 +4,24 @@ CLASS z2ui5_cl_smp_app_489 DEFINITION PUBLIC.
     INTERFACES z2ui5_if_app.
 
     TYPES:
-      BEGIN OF t_news,
+      BEGIN OF ty_s_news,
         text   TYPE string,
         author TYPE string,
-      END OF t_news,
-      tt_news TYPE STANDARD TABLE OF t_news
-                   WITH NON-UNIQUE DEFAULT KEY.
+      END OF ty_s_news.
+    TYPES ty_t_news TYPE STANDARD TABLE OF ty_s_news WITH NON-UNIQUE DEFAULT KEY.
 
     DATA news_input TYPE string.
     DATA author_input TYPE string.
-    DATA news_list TYPE tt_news.
-    DATA connections TYPE int8.
+    DATA t_news TYPE ty_t_news.
+    DATA connections TYPE i.
+    DATA ws_message TYPE string.
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
 
+    METHODS on_init.
     METHODS on_event.
+    METHODS on_event_post.
+    METHODS on_event_received.
     METHODS view_display.
     METHODS popover_display.
   PRIVATE SECTION.
@@ -30,16 +33,18 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
   METHOD z2ui5_if_app~main.
 
     me->client = client.
-
     IF client->check_on_init( ).
-      connections = z2ui5_cl_smp_app_489_ws=>get_active_connections( ).
+      on_init( ).
+    ELSEIF client->check_on_event( ).
+      on_event( ).
     ENDIF.
 
-    IF client->get( )-event IS NOT INITIAL.
-      on_event( ).
-      client->view_model_update( ).
-      RETURN.
-    ENDIF.
+  ENDMETHOD.
+
+
+  METHOD on_init.
+
+    connections = z2ui5_cl_smp_app_489_ws=>get_active_connections( ).
 
     view_display( ).
 
@@ -49,13 +54,68 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
   METHOD on_event.
 
     CASE client->get( )-event.
+      WHEN `POST`.
+        on_event_post( ).
+      WHEN `WS_RECEIVED`.
+        on_event_received( ).
       WHEN `CLEAR`.
-
-        news_list = VALUE #( ).
+        t_news = VALUE #( ).
       WHEN `CLICK_HINT_ICON`.
-
         popover_display( ).
+        RETURN.
+    ENDCASE.
 
+    " The view is displayed once, on init - the Websocket control lives in
+    " it and must not be torn down and reconnected on every message, so
+    " every event only refreshes the model.
+    client->view_model_update( ).
+
+  ENDMETHOD.
+
+
+  METHOD on_event_post.
+
+    DATA(s_news) = VALUE ty_s_news(
+        text   = news_input
+        author = COND #( WHEN author_input IS INITIAL THEN `Anonymous` ELSE author_input ) ).
+
+    TRY.
+        " Published from ABAP straight into the AMC channel - every APC
+        " connection bound to it, this app's own included, receives it back
+        " through the Websocket control.
+        z2ui5_cl_smp_app_489_ws=>send( z2ui5_cl_ajson=>create_empty(
+            )->set(
+                iv_path         = `/`
+                iv_val          = s_news
+                iv_ignore_empty = abap_false
+            )->stringify( ) ).
+        news_input = ``.
+      CATCH cx_root INTO DATA(error).
+        client->message_box_display( error->get_text( ) ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD on_event_received.
+
+    CASE ws_message.
+      WHEN z2ui5_cl_smp_app_489_ws=>c_msg-__new_connection__.
+        connections = connections + 1.
+
+      WHEN z2ui5_cl_smp_app_489_ws=>c_msg-__closed__.
+        connections = connections - 1.
+
+      WHEN OTHERS.
+        TRY.
+            DATA(s_news) = VALUE ty_s_news( ).
+            z2ui5_cl_ajson=>parse( ws_message
+              )->to_abap_corresponding_only(
+              )->to_abap( IMPORTING ev_container = s_news ).
+            INSERT s_news INTO TABLE t_news.
+          CATCH z2ui5_cx_ajson_error INTO DATA(error).
+            client->message_toast_display( error->get_text( ) ).
+        ENDTRY.
     ENDCASE.
 
   ENDMETHOD.
@@ -82,12 +142,27 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
            tooltip   = `Sample information`
            press     = client->_event( `CLICK_HINT_ICON` ) ).
 
+    page->message_strip(
+        text     = `This sample consumes an ABAP Push Channel without a line of JavaScript: the z2ui5:Websocket ` &&
+                   `custom control keeps the connection open, reports every message through its 'received' event ` &&
+                   `and publishing goes back into the AMC channel from ABAP.`
+        type     = `Information`
+        showicon = abap_true
+        class    = `sapUiSmallMargin` ).
+
     IF icfactive = abap_false.
       page->message_strip(
           text    = `ICF Service '/sap/bc/apc/sap/z2ui5_apc_smp_2' is not active. WebSocket communication will not work. Please activate the ICF Service in transaction SICF.`
           type    = `Warning`
           visible = abap_true ).
     ENDIF.
+
+    " The connection itself: an invisible control that writes each inbound
+    " message into WS_MESSAGE and raises WS_RECEIVED so the app can process it.
+    page->_z2ui5( )->websocket(
+        path     = `/sap/bc/apc/sap/z2ui5_apc_smp_2`
+        value    = client->_bind( ws_message )
+        received = client->_event( `WS_RECEIVED` ) ).
 
     DATA(form) = page->simple_form( editable = abap_true
                                     title    = `Publish news`
@@ -96,10 +171,7 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
 
     form->feed_input(
         value = client->_bind( news_input )
-        post  = client->_event_client(
-                  val   = `Z2UI5`
-                  t_arg = VALUE #( ( `feedInputPost` ) )
-                ) ).
+        post  = client->_event( `POST` ) ).
 
     form->label( text = `Author`
        )->input( value       = client->_bind( author_input )
@@ -107,7 +179,7 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
 
     page->list(
               headertext = `News`
-              items      = client->_bind( news_list )
+              items      = client->_bind( t_news )
          )->feed_list_item(
               sender   = `{AUTHOR}`
               text     = `{TEXT}`
@@ -123,50 +195,6 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
         text  = `Clear`
         icon  = `sap-icon://clear-all`
         press = client->_event( `CLEAR` ) ).
-
-    IF client->check_on_init( ).
-      view->_generic( name = `script`
-                      ns   = `html`
-         )->_cc_plain_xml(
-            `(()=>{ ` &&
-            `  const ws_url = (window.location.origin + '/sap/bc/apc/sap/z2ui5_apc_smp_2').replace('http','ws');` &&
-            `  try { ` &&
-            `   ws = new WebSocket(ws_url);` &&
-            `  } catch (err) {` &&
-            `    alert(err);` &&
-            `  }` &&
-            `  ws.onopen = ()=>{};` &&
-            `  ws.onmessage = (msg)=>{` &&
-            `    const model = z2ui5.oController.oView.getModel();` &&
-            `    const data = model.getData();` &&
-            `    if (msg.data === '` && z2ui5_cl_smp_app_489_ws=>c_msg-__new_connection__ && `') {` &&
-            `      data.CONNECTIONS += 1;` &&
-            `    } else if (msg.data === '` && z2ui5_cl_smp_app_489_ws=>c_msg-__closed__ && `') {` &&
-            `      data.CONNECTIONS -= 1;` &&
-            `    } else {` &&
-            `      data.NEWS_LIST.push(JSON.parse(msg.data));` &&
-            `    }` &&
-            `    model.setData(data);` &&
-            `  };` &&
-            `  ws.onclose = (msg)=>{};` &&
-            `})()` ).
-
-      view->_generic( name = `script`
-                      ns   = `html`
-          )->_cc_plain_xml(
-             `z2ui5.feedInputPost = () => { ` &&
-             `  const model = z2ui5.oView.getModel();` &&
-             `  const data = model.getData();` &&
-             `  ws.send(JSON.stringify({ ` &&
-             `    TEXT : data.NEWS_INPUT,` &&
-             `    AUTHOR : data.AUTHOR_INPUT ` &&
-             `  }));` &&
-             `  setTimeout( () => { ` &&
-             `    data.NEWS_INPUT = "";` &&
-             `    model.setData(data);` &&
-             `  }, 10 ); ` &&
-             `}` ).
-    ENDIF.
 
     client->view_display( view->stringify( ) ).
 

--- a/src/01/02/z2ui5_cl_smp_app_489.clas.abap
+++ b/src/01/02/z2ui5_cl_smp_app_489.clas.abap
@@ -15,6 +15,8 @@ CLASS z2ui5_cl_smp_app_489 DEFINITION PUBLIC.
     DATA t_news TYPE ty_t_news.
     DATA connections TYPE i.
     DATA ws_message TYPE string.
+    DATA ws_active TYPE abap_bool.
+    DATA ws_status TYPE string.
   PROTECTED SECTION.
     DATA client TYPE REF TO z2ui5_if_client.
 
@@ -22,6 +24,8 @@ CLASS z2ui5_cl_smp_app_489 DEFINITION PUBLIC.
     METHODS on_event.
     METHODS on_event_post.
     METHODS on_event_received.
+    METHODS on_event_toggle.
+    METHODS on_event_error.
     METHODS view_display.
     METHODS popover_display.
   PRIVATE SECTION.
@@ -44,7 +48,11 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
 
   METHOD on_init.
 
+    " Counted before the control connects - our own connection is added
+    " when the APC handler broadcasts __NEW_CONNECTION__ back to us.
     connections = z2ui5_cl_smp_app_489_ws=>get_active_connections( ).
+    ws_active   = abap_true.
+    ws_status   = `Connected`.
 
     view_display( ).
 
@@ -58,6 +66,10 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
         on_event_post( ).
       WHEN `WS_RECEIVED`.
         on_event_received( ).
+      WHEN `WS_ERROR`.
+        on_event_error( ).
+      WHEN `TOGGLE_CONNECTION`.
+        on_event_toggle( ).
       WHEN `CLEAR`.
         t_news = VALUE #( ).
       WHEN `CLICK_HINT_ICON`.
@@ -121,6 +133,44 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD on_event_toggle.
+
+    " The ToggleButton binds WS_ACTIVE two-way, so the control has already
+    " opened or closed the connection client-side when this event arrives -
+    " only the counter and the label are left to sort out.
+    IF ws_active = abap_true.
+
+      " Reconnecting needs no counting here either: __NEW_CONNECTION__
+      " comes back through the reopened connection and adds us.
+      ws_status = `Connected`.
+
+    ELSE.
+
+      " We are gone, so the __CLOSED__ broadcast the others receive never
+      " reaches us - drop ourselves from the count directly.
+      connections = connections - 1.
+      ws_status   = `Disconnected`.
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD on_event_error.
+
+    ws_active = abap_false.
+    ws_status = `Disconnected`.
+    " The connection is down, so the count can no longer be maintained from
+    " the broadcasts - read it from the channel instead.
+    connections = z2ui5_cl_smp_app_489_ws=>get_active_connections( ).
+
+    client->message_box_display(
+        text = |The WebSocket connection failed ({ client->get_event_arg( 1 ) }): { client->get_event_arg( 2 ) }|
+        type = `error` ).
+
+  ENDMETHOD.
+
+
   METHOD view_display.
 
     SELECT
@@ -145,7 +195,8 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
     page->message_strip(
         text     = `This sample consumes an ABAP Push Channel without a line of JavaScript: the z2ui5:Websocket ` &&
                    `custom control keeps the connection open, reports every message through its 'received' event ` &&
-                   `and publishing goes back into the AMC channel from ABAP.`
+                   `and a failure through 'error'; publishing goes back into the AMC channel from ABAP. The ` &&
+                   `button in the footer opens and closes the connection.`
         type     = `Information`
         showicon = abap_true
         class    = `sapUiSmallMargin` ).
@@ -158,20 +209,33 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
     ENDIF.
 
     " The connection itself: an invisible control that writes each inbound
-    " message into WS_MESSAGE and raises WS_RECEIVED so the app can process it.
-    page->_z2ui5( )->websocket(
-        path     = `/sap/bc/apc/sap/z2ui5_apc_smp_2`
-        value    = client->_bind( ws_message )
-        received = client->_event( `WS_RECEIVED` ) ).
+    " message into WS_MESSAGE and raises WS_RECEIVED so the app can process
+    " it. Built generically rather than through _z2ui5( )->websocket( ),
+    " because that builder method predates the control's error event.
+    page->_generic(
+        name   = `Websocket`
+        ns     = `z2ui5`
+        t_prop = VALUE #(
+            ( n = `path`        v = `/sap/bc/apc/sap/z2ui5_apc_smp_2` )
+            ( n = `value`       v = client->_bind( ws_message ) )
+            ( n = `checkActive` v = client->_bind( ws_active ) )
+            ( n = `received`    v = client->_event( `WS_RECEIVED` ) )
+            ( n = `error`       v = client->_event(
+                                        val   = `WS_ERROR`
+                                        t_arg = VALUE #( ( `${$parameters>/code}` )
+                                                         ( `${$parameters>/message}` ) ) ) ) ) ).
 
     DATA(form) = page->simple_form( editable = abap_true
                                     title    = `Publish news`
                                     class    = `sapUiTinyMarginBottom`
                     )->content( `form` ).
 
+    " Publishing while disconnected would work - it goes into the channel
+    " from ABAP - but the app would not see its own news come back.
     form->feed_input(
-        value = client->_bind( news_input )
-        post  = client->_event( `POST` ) ).
+        value   = client->_bind( news_input )
+        enabled = client->_bind( ws_active )
+        post    = client->_event( `POST` ) ).
 
     form->label( text = `Author`
        )->input( value       = client->_bind( author_input )
@@ -190,6 +254,15 @@ CLASS z2ui5_cl_smp_app_489 IMPLEMENTATION.
         text        = client->_bind( connections )
         colorscheme = `7`
         icon        = `sap-icon://connected` ).
+
+    " Two-way bound to the control's checkActive, so pressing it opens or
+    " closes the connection in the browser right away; the roundtrip only
+    " brings the counter and the label up to date.
+    footer->toggle_button(
+        text    = client->_bind( ws_status )
+        icon    = `sap-icon://connected`
+        pressed = client->_bind( ws_active )
+        press   = client->_event( `TOGGLE_CONNECTION` ) ).
 
     footer->toolbar_spacer( )->button(
         text  = `Clear`

--- a/src/01/02/z2ui5_cl_smp_app_489_ws.clas.abap
+++ b/src/01/02/z2ui5_cl_smp_app_489_ws.clas.abap
@@ -10,22 +10,24 @@ CLASS z2ui5_cl_smp_app_489_ws DEFINITION PUBLIC
         __closed__         TYPE string VALUE `__CLOSED__` ##NO_TEXT,
       END OF c_msg.
 
-    CLASS-METHODS: get_active_connections
+    CLASS-METHODS get_active_connections
       RETURNING
         VALUE(result) TYPE i.
 
-    METHODS if_apc_wsp_extension~on_message REDEFINITION.
+    " Publishing is done from the app in ABAP - the browser only listens,
+    " so this handler never redefines on_message.
+    CLASS-METHODS send
+      IMPORTING
+        i_message TYPE string
+      RAISING
+        cx_amc_error.
+
     METHODS if_apc_wsp_extension~on_start REDEFINITION.
     METHODS if_apc_wsp_extension~on_close REDEFINITION.
   PROTECTED SECTION.
     CLASS-METHODS get_producer
       RETURNING
         VALUE(producer) TYPE REF TO if_amc_message_producer_text
-      RAISING
-        cx_amc_error.
-    CLASS-METHODS send
-      IMPORTING
-        i_message TYPE string
       RAISING
         cx_amc_error.
   PRIVATE SECTION.
@@ -38,17 +40,6 @@ CLASS z2ui5_cl_smp_app_489_ws IMPLEMENTATION.
 
     producer ?= cl_amc_channel_manager=>create_message_producer( i_application_id = c_amc_application_id
                                                                  i_channel_id     = c_channel_id ).
-
-  ENDMETHOD.
-
-
-  METHOD if_apc_wsp_extension~on_message.
-
-    TRY.
-        send( i_message->get_text( ) ).
-      CATCH cx_root INTO DATA(error).
-        RAISE SHORTDUMP error.
-    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
## Summary
Refactored the SMP app 489 to replace inline JavaScript WebSocket handling with a declarative `z2ui5:Websocket` custom control. This eliminates manual JS code and moves all connection/message logic into ABAP event handlers.

## Key Changes

**z2ui5_cl_smp_app_489.clas.abap:**
- Standardized type naming: `t_news` → `ty_s_news`, `tt_news` → `ty_t_news`
- Renamed data member: `news_list` → `t_news`
- Changed `connections` type from `int8` to `i`
- Added new data members: `ws_message`, `ws_active`, `ws_status` to track WebSocket state
- Extracted initialization logic into new `on_init()` method
- Refactored `on_event()` to dispatch to specialized handlers:
  - `on_event_post()` – publishes news to AMC channel
  - `on_event_received()` – processes inbound WebSocket messages
  - `on_event_toggle()` – handles connection open/close
  - `on_event_error()` – handles WebSocket errors
- Removed ~50 lines of inline JavaScript that manually managed WebSocket connection and message handling
- Added `z2ui5:Websocket` custom control in `view_display()` with bindings for `value`, `checkActive`, `received`, and `error` events
- Added informational message strip explaining the AMC/WebSocket pattern
- Replaced custom `feedInputPost` event with standard `POST` event
- Added toggle button to open/close connection client-side with two-way binding to `ws_active`

**z2ui5_cl_smp_app_489_ws.clas.abap:**
- Removed `if_apc_wsp_extension~on_message` redefinition (no longer echoes messages back)
- Moved `send()` method to public section with documentation
- Reordered method declarations for clarity

## Implementation Details
- The `z2ui5:Websocket` control now manages the browser-side connection lifecycle
- Messages flow: ABAP → AMC channel → all connected browsers (including sender)
- Connection state is maintained via `ws_active` (boolean) and `ws_status` (label)
- The control's `error` event passes error code and message as event arguments
- Publishing works from ABAP regardless of connection state, but the app only sees its own news when connected

https://claude.ai/code/session_01VZw8icDrvMdsjLt7c2GmvA